### PR TITLE
simple github actions workflow for continous integration

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,33 @@
+name: anduril
+
+on:
+  push:
+    branches: [ "main", "actions" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Requirements
+      run: |
+        sudo apt-get -qqy update
+        sudo apt-get -qqy install avr-libc binutils-avr wget gcc-avr unzip
+    - name: Install Device Family Pack
+      run: |
+        ./make dfp
+    - name: Compile All
+      run: |
+        ./bin/build-all.sh
+        echo "ARTIFACT_NAME=${GITHUB_WORKFLOW}-${GITHUB_REF_NAME}-$(git rev-parse --short ${GITHUB_SHA})-${GITHUB_RUN_NUMBER}" >> "${GITHUB_ENV}"
+    - name: Store Artifacts
+      uses: actions/upload-artifact@master
+      with:
+        name: ${{ env.ARTIFACT_NAME }}
+        if-no-files-found: error
+        path: |
+          hex/*.hex


### PR DESCRIPTION
[example run](https://github.com/gretel/anduril-tk/actions/runs/6758789018/job/18370774611) - it's not finishing cause of missing files:

```shell
 head: cannot open 'hw/hank/noctigon-k9.3/nofet/model' for reading: No such file or directory
```

serves as an example why continous integration can be useful 😸 please see a [finished run](https://github.com/gretel/anduril-sre/actions/runs/6758435159) of a similar workflow.

guess lines in your `.gitignore` did keep some files from getting commited:

```gitignore
*.[0123456789]
*.[0123456789][0123456789]
```
regards