### PR TITLE
Fixes syntax errors when USE_SIMPLE_UI is undefined

### DIFF
--- a/ui/anduril/channel-modes.c
+++ b/ui/anduril/channel-modes.c
@@ -119,7 +119,6 @@ uint8_t channel_mode_state(Event event, uint16_t arg) {
         return EVENT_HANDLED;
     }
     #endif  // ifndef DONT_USE_DEFAULT_CHANNEL_ARG_MODE
-    #endif  // ifdef USE_CHANNEL_MODE_ARGS
 
     #if defined(USE_SIMPLE_UI)
     // remaining mappings aren't "simple", so stop here
@@ -135,6 +134,7 @@ uint8_t channel_mode_state(Event event, uint16_t arg) {
         return EVENT_HANDLED;
     }
     #endif
+    #endif  // ifdef USE_CHANNEL_MODE_ARGS
 
     return EVENT_NOT_HANDLED;
 }


### PR DESCRIPTION
As per the title.

As discussed previously in the old Launchpad repo: https://bugs.launchpad.net/flashlight-firmware/+bug/2027883

And on BLF: https://budgetlightforum.com/t/anduril-2-feature-change-suggestions/218045/199