### PR TITLE
Per-user config implementation

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -6,10 +6,9 @@
 # Instead of using a Makefile, since most of the firmwares here build in the
 # same exact way, here's a script to do the same thing
 
-if [ -z "$1" ]; then
-  echo "Usage: build.sh TARGET USER"
-  echo "Example: build.sh hw/hank/emisar-d4/anduril.h users/myuser"
-  echo "(but USER isn't implemented yet)"
+if [ 0 = "$#" ]; then
+  echo "Usage: build.sh TARGET"
+  echo "Example: build.sh hw/hank/emisar-d4/anduril.h"
   exit
 fi
 
@@ -20,6 +19,8 @@ TARGET=$1 ; shift
 UI=$(basename $TARGET .h)
 MODEL=$(dirname $TARGET)
 PROGRAM="ui/$UI/$UI"
+USER_MODEL_CFG=$(dirname ${TARGET//hw/users\/$USER} )/config.h
+USER_DEFAULT_CFG=users/$USER/config.h
 
 # figure out the model number
 MODEL_NUMBER=$(head -1 $MODEL/model)
@@ -47,7 +48,6 @@ export CC=avr-gcc
 export CPP=avr-cpp
 export OBJCOPY=avr-objcopy
 export DFPFLAGS="-B $DFPPATH/gcc/dev/$MCUNAME/ -I $DFPPATH/include/"
-# TODO: include $user/ first so it can override other stuff
 INCLUDES="-I ui -I hw -I. -I.. -I../.. -I../../.."
 export CFLAGS="  -Wall -g -Os -mmcu=$MCUNAME -c -std=gnu99 -fgnu89-inline -fwhole-program $MCUFLAGS $INCLUDES -fshort-enums $DFPFLAGS"
 export CPPFLAGS="-Wall -g -Os -mmcu=$MCUNAME -C -std=gnu99 -fgnu89-inline -fwhole-program $MCUFLAGS $INCLUDES -fshort-enums $DFPFLAGS"
@@ -60,6 +60,16 @@ OTHERFLAGS="-DCFG_H=$TARGET -DMODEL_NUMBER=\"$MODEL_NUMBER\""
 for arg in "$*" ; do
   OTHERFLAGS="$OTHERFLAGS $arg"
 done
+
+if [ -f $USER_DEFAULT_CFG ]; then
+  echo "  Using custom configuration from $USER_DEFAULT_CFG"
+  OTHERFLAGS="$OTHERFLAGS -DUSER_DEFAULT_H=$USER_DEFAULT_CFG"
+fi
+
+if [ -f $USER_MODEL_CFG ]; then
+  echo "  Using custom configuration from $USER_MODEL_CFG"
+  OTHERFLAGS="$OTHERFLAGS -DUSER_MODEL_H=$USER_MODEL_CFG"
+fi
 
 function run () {
   #echo $1 ; shift

--- a/docs/per-user-config.md
+++ b/docs/per-user-config.md
@@ -1,4 +1,26 @@
 # Per-User Configuration
 
-(write me)
+To customize the configuration for all models, create a
+`users/<username>/config.h` file.
 
+To customize the configuration for a specific model, create a
+`users/<username>/<manufacturer>/<model>/config.h` file (same directory
+structure as that under `hw`, just replace `hw` with `users/<username>`).
+
+Both customization methods can be used together, ie. you can have a global
+`config.h` with all your favorite settings and a model-specific `config.h`
+to override some of them on a specific light.
+
+In the global or model-specific `config.h` you can override default settings
+like this:
+
+    #undef RAMP_SMOOTH_FLOOR
+    #define RAMP_SMOOTH_FLOOR    30
+
+To use these customizations, set the USER variable when running `make`:
+
+    USER=username ./make [target]
+
+If you place customizations in a directory under `users/` that matches your
+Unix username (ie. `users/<your username>`), they will be used automatically
+and you don't need to specify the username in the `make` command.

--- a/ui/anduril/anduril.c
+++ b/ui/anduril/anduril.c
@@ -44,6 +44,15 @@
 #include "fsm/tk.h"
 #include incfile(CFG_H)
 
+// Per-user global overrides
+#ifdef USER_DEFAULT_H
+#include incfile(USER_DEFAULT_H)
+#endif
+
+// Per-user model-specific overrides
+#ifdef USER_MODEL_H
+#include incfile(USER_MODEL_H)
+#endif
 
 /********* Include headers which need to be before FSM *********/
 

--- a/users/.gitignore
+++ b/users/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!README.md
+

--- a/users/README.md
+++ b/users/README.md
@@ -1,0 +1,3 @@
+# Per-User Configuration
+
+See [Per-User Configuration](../docs/per-user-config.md)


### PR DESCRIPTION
Here's a proposed implementation for the per-user customization functionality mentioned in the README. That's a brilliant idea.

I think my approach is better than just adding the custom user directory at the beginning of INCLUDES as suggested by a comment in build.sh, as this allows one to override individual settings without having to replicate the entire config-defaults.h and/or anduril.h.

I don't know if this is at all what you had in mind but let me know what you think!