### PR TITLE
Add alternate number entry that allows multiples of 10

### DIFF
--- a/hw/hank/emisar-d1v2/7135-fet/anduril.h
+++ b/hw/hank/emisar-d1v2/7135-fet/anduril.h
@@ -15,6 +15,7 @@
 //  so it's unlikely that anyone needs this, but it doesn't hurt anything)
 #define USE_AUX_RGB_LEDS
 #define USE_AUX_RGB_LEDS_WHILE_ON  25
+#define USE_NUMBER_ENTRY_BIGNUM
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 // safe limit ~50% power

--- a/hw/hank/emisar-d1v2/linear-fet/anduril.h
+++ b/hw/hank/emisar-d1v2/linear-fet/anduril.h
@@ -13,6 +13,7 @@
 // the aux LEDs are in the button, so use them while main LEDs are on
 #define USE_AUX_RGB_LEDS
 #define USE_AUX_RGB_LEDS_WHILE_ON  25
+#define USE_NUMBER_ENTRY_BIGNUM
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 // safe limit: max regulated power

--- a/hw/hank/emisar-d1v2/nofet/anduril.h
+++ b/hw/hank/emisar-d1v2/nofet/anduril.h
@@ -13,6 +13,7 @@
 // the aux LEDs are in the button, so use them while main LEDs are on
 #define USE_AUX_RGB_LEDS
 #define USE_AUX_RGB_LEDS_WHILE_ON  25
+#define USE_NUMBER_ENTRY_BIGNUM
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 // safe limit: same as regular ramp

--- a/hw/hank/emisar-d4k-3ch/anduril.h
+++ b/hw/hank/emisar-d4k-3ch/anduril.h
@@ -12,6 +12,7 @@
 // turn on the aux LEDs while main LEDs are on
 // (in case there's a RGB button)
 #define USE_AUX_RGB_LEDS_WHILE_ON  40
+#define USE_NUMBER_ENTRY_BIGNUM
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 // channel modes...
@@ -102,3 +103,4 @@
 // for consistency with KR4 (not otherwise necessary though)
 #define USE_SOFT_FACTORY_RESET
 
+#define USE_NUMBER_ENTRY_BIGNUM

--- a/hw/hank/noctigon-k1/anduril.h
+++ b/hw/hank/noctigon-k1/anduril.h
@@ -14,6 +14,7 @@
 // this light has three aux LED channels: R, G, B
 #define USE_AUX_RGB_LEDS
 #define USE_AUX_RGB_LEDS_WHILE_ON  5
+#define USE_NUMBER_ENTRY_BIGNUM
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 

--- a/hw/hank/noctigon-k1/boost/anduril.h
+++ b/hw/hank/noctigon-k1/boost/anduril.h
@@ -17,6 +17,7 @@
 // this light has three aux LED channels: R, G, B
 #define USE_AUX_RGB_LEDS
 #define USE_AUX_RGB_LEDS_WHILE_ON  25
+#define USE_NUMBER_ENTRY_BIGNUM
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 #if 0  // old, 10-bit PWM method

--- a/hw/hank/noctigon-k1/sbt90/anduril.h
+++ b/hw/hank/noctigon-k1/sbt90/anduril.h
@@ -14,6 +14,7 @@
 // this light has three aux LED channels: R, G, B
 #define USE_AUX_RGB_LEDS
 #define USE_AUX_RGB_LEDS_WHILE_ON  10
+#define USE_NUMBER_ENTRY_BIGNUM
 #define USE_INDICATOR_LED_WHILE_RAMPING
 
 

--- a/hw/wurkkos/fc13/anduril.h
+++ b/hw/wurkkos/fc13/anduril.h
@@ -10,5 +10,6 @@
 
 // turn on the aux LEDs while main LEDs are on
 #define USE_AUX_RGB_LEDS_WHILE_ON  20
+#define USE_NUMBER_ENTRY_BIGNUM
 #define USE_INDICATOR_LED_WHILE_RAMPING
 

--- a/hw/wurkkos/ts11/anduril.h
+++ b/hw/wurkkos/ts11/anduril.h
@@ -12,5 +12,6 @@
 // (but not until the main LEDs are bright enough to overpower the aux)
 // (setting this lower makes an annoying effect on some levels)
 #define USE_AUX_RGB_LEDS_WHILE_ON  50
+#define USE_NUMBER_ENTRY_BIGNUM
 #define USE_INDICATOR_LED_WHILE_RAMPING
 


### PR DESCRIPTION
In number entry mode, when holding for +10, keep holding and it will add additional increments of 10. Added to lights with `USE_AUX_RGB_LEDS_WHILE_ON` with use for configurable RGB voltage aux (see PR #10) in mind.