### PR TITLE
Update make shebang for portability

### DIFF
--- a/make
+++ b/make
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Anduril / FSM "make" script
 # Copyright (C) 2023 Selene ToyKeeper
 # SPDX-License-Identifier: GPL-3.0-or-later


### PR DESCRIPTION
Updated make

Changed shebang to `#!/usr/bin/env bash `for [portability](https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability): Different *nixes put bash in different places, and using /usr/bin/env is a workaround to run the first bash found on the PATH.