### PR TITLE
More smooth steps (optionally for tactical mode)

### DIFF
--- a/ui/anduril/load-save-config-fsm.h
+++ b/ui/anduril/load-save-config-fsm.h
@@ -116,6 +116,9 @@ typedef struct Config {
     #endif
     #ifdef USE_TACTICAL_MODE
         uint8_t tactical_levels[3];
+      #ifdef USE_TACTICAL_MODE_SMOOTH_STEPS
+        uint8_t tactical_smooth_steps;
+      #endif
     #endif
 
     ///// hardware config / globals menu

--- a/ui/anduril/load-save-config.h
+++ b/ui/anduril/load-save-config.h
@@ -161,6 +161,9 @@ Config cfg = {
     #endif
     #ifdef USE_TACTICAL_MODE
         .tactical_levels = { TACTICAL_LEVELS },
+    #ifdef USE_TACTICAL_MODE_SMOOTH_STEPS
+        .tactical_smooth_steps = 0;
+    #endif
     #endif
 
     ///// hardware config / globals menu

--- a/ui/anduril/lockout-mode.c
+++ b/ui/anduril/lockout-mode.c
@@ -26,11 +26,11 @@ uint8_t lockout_state(Event event, uint16_t arg) {
             if (cfg.manual_memory) lvl = cfg.manual_memory;
             #endif
         }
-        set_level(lvl);
+        off_state_set_level(lvl);
     }
     // button was released
     else if ((event & (B_CLICK | B_PRESS)) == (B_CLICK)) {
-        set_level(0);
+        off_state_set_level(0);
     }
     #endif  // ifdef USE_MOON_DURING_LOCKOUT_MODE
 


### PR DESCRIPTION
Based on @SammysHP's version (https://github.com/ToyKeeper/anduril/pull/18), but optional both at build time (save some flash on t85 lights) and runtime (because in general, people using tactical mode are using it because they *want* instant-on at a high level.