### PR TITLE
Add logic to calculate a version string based on repo state

### DIFF
--- a/bin/build-all.sh
+++ b/bin/build-all.sh
@@ -9,6 +9,11 @@
 # enable "**" for recursive glob (requires bash)
 shopt -s globstar
 
+if [ "${DEBUG}" == "1" ]; then
+  set -x
+  export DEBUG
+fi
+
 if [ "$#" -gt 0 ]; then
   # multiple search terms with "AND"
   SEARCH=( "$@" )
@@ -17,13 +22,160 @@ if [ "$#" -gt 0 ]; then
 fi
 
 # TODO: detect UI from $0 and/or $*
-UI=anduril
+export UI=anduril
 
 mkdir -p hex
 
 # TODO: use a git tag for the version, instead of build date
 # TODO: use build/version.h instead of $UI/version.h ?
-date '+#define VERSION_NUMBER "%Y-%m-%d"' > ui/$UI/version.h
+
+case "${VERSION_NUMBER_SCHEME}" in
+  ""|"builddate"|"build-date")
+  #date '+#define VERSION_NUMBER "%Y-%m-%d"' > ui/$UI/version.h
+  VERSION_STRING=$(date '+%Y-%m-%d')
+  ;;
+  "manual")
+    #$VERSION_STRING should have already been set
+    if [[ -z "${VERSION_STRING}" ]]
+    then
+      echo "ERROR: version number scheme set to manual but VERSION_STRING not found" >&2
+      exit 3
+    fi
+  ;;
+  "official-release")
+    USE_CALC_VERSION=1
+    TAG_UPSTREAM="git+ssh://git@github.com/toykeeper/anduril"
+    TAG_UPSTREAM_FALLBACK="https://github.com/toykeeper/anduril"
+    # TODO: pull list of releases from github when it's done and build from that instead?
+    RELEASE_PATTERNS="r*"
+  ;;
+  "local-tags")
+    USE_CALC_VERSION=1
+    TAG_UPSTREAM=""
+    RELEASE_PATTERNS=""
+  ;;
+  "local-releases")
+    USE_CALC_VERSION=1
+    TAG_UPSTREAM=""
+    TAG_UPSTREAM_FALLBACK=""
+    if [[ -z "${RELEASE_PATTERNS}" ]]
+    then
+      echo "No release patterns found; using default (${DEFAULT_RELEASE_PATTERN}). To override, use --release-patterns or env var RELEASE_PATTERNS with a list of glob patterns to consider as releases" >&2
+      RELEASE_PATTERNS=${DEFAULT_RELEASE_PATTERN}
+    fi
+  ;;
+esac
+
+
+fetch_tags_fail(){
+  case $FETCH_TAGS_FAIL_ACTION in
+    abort)
+      echo "ERROR: failed to fetch tags" >&2
+      exit 1
+    ;;
+    continue)
+      echo "WARNING: failed to fetch tags" >&2
+    ;;
+    fallback)
+      echo "WARNING: failed to fetch tags; falling back to build date for version number" >&2
+      VERSION_STRING=$(date '+%Y-%m-%d')
+      SKIP_CALC_VERSION=1
+    ;;
+    *)
+      echo "Failed to fetch tags. To suppress this message, you can use --fetch-tags-fail-action=[abort|continue]" >&2
+      exit 1
+    ;;
+  esac
+}
+
+if [[ "${USE_CALC_VERSION}" == "1" ]]
+then
+  if [[ -n "${RELEASE_PATTERNS}" ]]
+  then
+    release_pattern_refs=()
+    release_pattern_match=()
+    IFS=";" read -r -a patterns <<< "${RELEASE_PATTERNS}"
+    for pattern in "${patterns[@]}"
+    do
+      #TODO: build *specific* release pattern match based on remote release list?
+      release_pattern_refs+=("refs/tags/${pattern}")
+      release_pattern_match+=("--match ${pattern}")
+    done
+  fi
+
+  if [[ -n "${TAG_UPSTREAM}" ]]
+  then
+    git fetch --tags "${TAG_UPSTREAM}"
+    # shellcheck disable=SC2181
+    if [[ "${?}" != "0" ]]
+    then
+      if [[ -n "${TAG_UPSTREAM_FALLBACK}" ]]
+      then
+        git fetch --tags "${TAG_UPSTREAM_FALLBACK}"
+        if [[ "${?}" != "0" ]]
+        then
+          fetch_tags_fail
+        fi
+      else
+        fetch_tags_fail
+      fi
+    fi
+  fi
+
+  if [[ -z "${SKIP_CALC_VERSION}" ]]
+  then
+    #shellcheck disable=SC2068
+    DIRTY=$(git describe --tags --dirty ${release_pattern_match[@]} )
+
+    if grep -qE "\-dirty$" <<< "${DIRTY}"
+    then
+      IS_DIRTY="-1"
+      # do a shift for next part
+      DIRTY_TMP="${DIRTY}"
+      # shellcheck disable=SC2001
+      DIRTY=$(sed 's/-dirty$//' <<< "${DIRTY_TMP}")
+    else
+      IS_DIRTY=""
+    fi
+
+    #if last part is g followed by some hex with at least one part before it, it's a commit hash of where we are
+    if grep -qE ".*-g[0-f]+$" <<< "${DIRTY}"
+    then
+      # TODO is there 100% always a commithash if there is a number of commits since tag? would be a weird edge case if not
+      #COMMITHASH_AFTER_TAG=$(sed -r -n 's/^.*-(g[0-f]+)/\1/p' <<< "${DIRTY}")
+      COMMITHASH_AFTER_TAG=$(sed -r -n 's/^.*-g([0-f]+)/\1/p' <<< "${DIRTY}")
+      echo "COMMITHASH_AFTER_TAG=${COMMITHASH_AFTER_TAG}"
+
+      #do a shift for next part
+      DIRTY_TMP="${DIRTY}"
+      DIRTY=$(sed -r 's/-g[0-f]+$//' <<< "${DIRTY_TMP}")
+      #if last part is an integer, with at least one more part before it, it's commits since tag
+      if grep -qE ".*-[0-9]+$" <<< "${DIRTY}"
+      then
+        COMMITS_SINCE_TAG=$(grep -oE "[0-9]+$" <<< "${DIRTY}")
+        echo COMMITS_SINCE_TAG="${COMMITS_SINCE_TAG}"
+
+        #do a shift for next part
+        DIRTY_TMP="${DIRTY}"
+        DIRTY=$(sed -r 's/-[0-9]+$//' <<< "${DIRTY_TMP}")
+      fi
+    else
+      COMMITS_SINCE_TAG=0
+      COMMITHASH_AFTER_TAG=""
+    fi
+
+    # rest should be the tag we have the status for
+    COMMITHASH_BASE="${DIRTY}"
+    echo "COMMITHASH_BASE=${COMMITHASH_BASE}"
+
+    # TODO: verify against remote repo here?
+
+    TAG_DATE=$(git log -1 --format=%cs r2023-10-31)
+
+    VERSION_STRING="${TAG_DATE}-${COMMITS_SINCE_TAG}${IS_DIRTY}-${COMMITHASH_AFTER_TAG}"
+  fi
+fi
+echo "#define VERSION_NUMBER \"${VERSION_STRING}\"" > ui/$UI/version.h
 
 PASS=0
 FAIL=0

--- a/make
+++ b/make
@@ -10,6 +10,13 @@
 # enable "**" for recursive glob (requires bash)
 shopt -s globstar
 
+# Default to build date until support for hex in version numbers exists
+export DEFAULT_VERSION_NUMBER_SCHEME=build-date
+#DEFAULT_VERSION_NUMBER_SCHEME=official-release
+
+# This should match the release pattern(s) used on the main repo
+export DEFAULT_RELEASE_PATTERN="r*"
+
 # figure out which operation was requested
 MODE="$1"
 
@@ -31,6 +38,21 @@ Usage: ./make TASK
 
 ... or TASK can be the partial name of a build target.
 
+Command-line arguments:
+  --help -h help /? /h /help                       Show this message
+  --debug                                          Show debug output from scripts
+  --version-string <string>                        Use <string> for the version number. Acceptable characters are 0-9 and '-'.
+  --version-build-date                             Use the date the firmware was built as a version number
+  --version-number-scheme <scheme>                 Use the stated version number scheme. Options are:
+                                                   - official-release: base the version number on the newest release from the project repo (default)
+                                                   - local-tags: base the version number on tags present within the local repo
+                                                   - local-releases: base the version number on tags present within the local repo that match the defined pattern to be considered releases
+                                                   - build-date: use the date that the firmware was built on. This was the default before 2023-10-31
+  --release-patterns <patterns>                    List of glob patterns for which tags should be considered releases, separated by ';', e.g. "r*;dev*" (default "r*")
+  --fetch-tags-fail-action [abort|continue|fallback]    If fetching tags from a remote repository, whether the build should abort, continue with cached tags, or fallback to a local build date
+
+By default the newest tag relevant to the working state of the source will be used to generate a version number, and if no tags are found, the user will be asked what to do, or the build fail if automated.
+
 Examples:
 
   # get rid of old clutter files
@@ -44,18 +66,18 @@ Examples:
   # Flash the Q8 firmware built in the previous command
   # (copy/paste the file path printed by the build script)
   ./make flash hex/sofirn-blf-q8.hex
+
 ENDOFHELP
 }
 
 # sub-command parser / dispatcher
 function main() {
   case "$MODE" in
-    -h|--help|help|/\?|/h|/help)
-      help
-      ;;
     clean)
       echo 'rm -vf -- **/*~ hex/*.hex ui/**/*.elf ui/**/*.o ui/**/*.cpp'
       rm -vf -- **/*~ hex/*.hex ui/**/*.elf ui/**/*.o ui/**/*.cpp
+      echo 'git checkout -- ui/*/version.h'
+      git checkout -- ui/*/version.h
       ;;
     dfp)
       shift
@@ -91,6 +113,117 @@ function make-docs () {
     cmark-gfm "$md" > "$html"
   done
 }
+
+# Parse and validate command line args
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --debug)
+      export DEBUG=1
+      shift
+    ;;
+    --help|help|-h|/\?|/h|/help)
+      help
+      exit 255
+    ;;
+    --fetch-tags-fail-action*)
+      shift # past arg
+      if [[ "${key}" =~ ^\-\-fetch\-tags\-fail\-action= ]] #is this in the form of --foo=bar?
+      then
+        FETCH_TAGS_FAIL_ACTION="$(cut -d '=' -f2 <<< "${key}")"
+      elif [[ -z "${1}" ]] || [[ "${1}" =~ ^\-\- ]] # is this followed by another long arg, or by nothing?
+      then
+        echo "--fetch-tags-fail-action requires an argument"
+        exit 1
+      else # in the form of --foo bar
+        FETCH_TAGS_FAIL_ACTION="${1}"
+        shift # past value
+      fi
+      case ${FETCH_TAGS_FAIL_ACTION} in
+        abort|continue|fallback)
+          export FETCH_TAGS_FAIL_ACTION
+        ;;
+        *)
+          echo "ERROR: unknown --fetch-tags-fail-action argument ${FETCH_TAGS_FAIL_ACTION}" >&2
+          exit 1
+        ;;
+      esac
+    ;;
+    --version-build-date)
+      shift # past arg
+      export VERSION_NUMBER_SCHEME="build-date"
+    ;;
+    --version-string*)
+      shift # past arg
+      export VERSION_NUMBER_SCHEME="manual"
+      if [[ "${key}" =~ ^\-\-version\-string= ]] #is this in the form of --foo=bar?
+      then
+        VERSION_STRING="$(cut -d '=' -f2 <<< "${key}")"
+      elif [[ -z "${1}" ]] || [[ "${1}" =~ ^\-\- ]] # is this followed by another long arg, or by nothing?
+      then
+        echo "--version-string requires an argument"
+        exit 1
+      else # in the form of --foo bar
+        VERSION_STRING="${1}"
+        shift # past value
+      fi
+      if [[ ! "${VERSION_STRING}" =~ ^[0-f][\-0-f]*[0-f]$ ]]
+      then
+        echo "ERROR: version number string can only contain the characters '-' and 0-f and can not start or end with '-'" >&2
+        exit 1
+      else
+        export VERSION_STRING
+      fi
+      export VERSION_STRING
+    ;;
+    --version-number-scheme*)
+      shift # past arg
+      if [[ "${key}" =~ ^\-\-version\-number\-scheme= ]] #is this in the form of --foo=bar?
+      then
+        VERSION_NUMBER_SCHEME="$(cut -d '=' -f2 <<< "${key}")"
+      elif [[ -z "${1}" ]] || [[ "${1}" =~ ^\-\- ]] # is this followed by another long arg, or by nothing?
+      then
+        echo "--version-number-scheme requires an argument"
+        exit 1
+      else # in the form of --foo bar
+        VERSION_NUMBER_SCHEME=${1}
+        shift # past value
+      fi
+      case ${VERSION_NUMBER_SCHEME} in
+      build-date|local-releases|local-tags|official-release)
+        export VERSION_NUMBER_SCHEME
+        ;;
+      *)
+        echo "ERROR: unknown --version-number-scheme argument ${VERSION_NUMBER_SCHEME}" >&2
+        exit 1
+      ;;
+      esac
+    ;;
+    --release-patterns*)
+      shift # past arg
+      if [[ "${key}" =~ ^\-\-release\-patterns= ]] #is this in the form of --foo=bar?
+      then
+        RELEASE_PATTERNS="$(cut -d '=' -f2 <<< "${key}")"
+      elif [[ -z "${1}" ]] || [[ "${1}" =~ ^\-\- ]] # is this followed by another long arg, or by nothing?
+      then
+        echo "--release-patterns requires an argument"
+        exit 1
+      else # in the form of --foo bar
+        RELEASE_PATTERNS=${1}
+        shift # past value
+      fi
+      export RELEASE_PATTERNS
+    ;;
+    *)
+      POSITIONAL+=("$1") # save it in an array for later
+      shift # past argument
+    ;;
+  esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
+[[ -z "${VERSION_NUMBER_SCHEME}" ]] && export VERSION_NUMBER_SCHEME=${DEFAULT_VERSION_NUMBER_SCHEME}
 
 # go to the repo root
 BASEDIR=$(dirname "$0")


### PR DESCRIPTION
At the moment this defaults to not doing anything differently,  but when the build supports hexadecimal in version numbers then this can be easily switched over.

New repo-based version number scheme example: `<model code>-2023-10-31[-61[-1][-b1dbfc5]]` (parts in `[]` may or may not be present)
`2023-10-31`: Date of the latest release this build is based on
`61`: If present, number of commits visible since latest release
`1`: If present, indicates the build was with the repo in a dirty state. Only possible to appear if `-61` part is present
`b1dbfc5`: Commit hash of the *current* commit. Only possible to appear if `-61` part is present

Also various additional small improvements to make script