### PR TITLE
bikeflash: Cap default brightness to MAX_BIKING_LEVEL, add optional default define

### DIFF
--- a/ui/anduril/load-save-config.h
+++ b/ui/anduril/load-save-config.h
@@ -118,7 +118,15 @@ Config cfg = {
         .strobe_delays = { 41, 67 },
     #endif
     #ifdef USE_BIKE_FLASHER_MODE
-        .bike_flasher_brightness = MAX_1x7135,
+        #ifndef DEFAULT_BIKING_LEVEL
+            #if MAX_1x7135 > MAX_BIKING_LEVEL
+                // Make sure fallback default doesn't exceed maximum (e.g. noFET)
+                #define DEFAULT_BIKING_LEVEL MAX_BIKING_LEVEL
+            #else
+                #define DEFAULT_BIKING_LEVEL MAX_1x7135
+            #endif
+        #endif
+        .bike_flasher_brightness = DEFAULT_BIKING_LEVEL,
     #endif
     #ifdef USE_BEACON_MODE
         // beacon timing


### PR DESCRIPTION
*Migrated from [original Launchpad merge request](https://code.launchpad.net/~digitalcircuit/flashlight-firmware/anduril2_fix_nofet_bikeflash/+merge/408124 )*

This fixes the issue where builds with a single voltage/current regulator (e.g. the Noctigon KR4 linear driver with noFET/FET disabled in firmware) put the default bike flasher brightness beyond `MAX_BIKING_LEVEL` (`120`) due to `MAX_1x7135 = 150` (`MAX_LEVEL`).

With this change, the default bike flasher brightness is the minimum of `MAX_1x7135` and `MAX_BIKING_LEVEL`, ensuring it never exceeds the maximum.

As a side effect, this provides a way to specify the default bike flasher brightness via `#define DEFAULT_BIKING_LEVEL`.  This is **not** checked against `MAX_BIKING_LEVEL`, for simplicity.

Alternatively, `strobe-modes.c` could be updated to check if the value exceeds `MAX_BIKING_LEVEL` at runtime.  However, that might take up more flash space.