### PR TITLE
Make USE_EXTENDED_SIMPLE_UI more configurable at build-time

### DIFF
--- a/hw/hank/anduril.h
+++ b/hw/hank/anduril.h
@@ -19,8 +19,8 @@
 // Allow 3C (or 6C) in Simple UI (toggle smooth or stepped ramping)
 #define USE_SIMPLE_UI_RAMPING_TOGGLE
 
-// allow Aux Config and Strobe Modes in Simple UI
-#define USE_EXTENDED_SIMPLE_UI
+// allow Aux Config, Strobe Modes, and Sunset Timer in Simple UI
+#define USE_EXTENDED_SIMPLE_UI 2
 
 // double click while on goes to full-power turbo, not ramp ceiling
 #define DEFAULT_2C_STYLE 1

--- a/hw/sofirn/blf-lt1-t1616/anduril.h
+++ b/hw/sofirn/blf-lt1-t1616/anduril.h
@@ -63,8 +63,8 @@
 // Allow 3C (or 6C) in Simple UI (toggle smooth or stepped ramping)
 #define USE_SIMPLE_UI_RAMPING_TOGGLE
 
-// allow Aux Config and Strobe Modes in Simple UI
-#define USE_EXTENDED_SIMPLE_UI
+// allow Aux Config, Sunset Timer, and Strobe Modes in Simple UI
+#define USE_EXTENDED_SIMPLE_UI 2
 
 #define USE_SOS_MODE
 #define USE_SOS_MODE_IN_BLINKY_GROUP

--- a/hw/sofirn/blf-lt1/anduril.h
+++ b/hw/sofirn/blf-lt1/anduril.h
@@ -60,7 +60,9 @@
 
 // Allow 3C in Simple UI for switching between smooth and stepped ramping
 #define USE_SIMPLE_UI_RAMPING_TOGGLE
-#define USE_EXTENDED_SIMPLE_UI
+
+// allow Aux Config, Sunset Timer, and Strobe Modes in Simple UI
+#define USE_EXTENDED_SIMPLE_UI 2
 
 // also at Sofirn's request, enable 2 click turbo (Anduril 1 style)
 #define DEFAULT_2C_STYLE  1

--- a/hw/sofirn/blf-q8-t1616/anduril.h
+++ b/hw/sofirn/blf-q8-t1616/anduril.h
@@ -54,8 +54,8 @@
 // Allow 3C in Simple UI for switching between smooth and stepped ramping
 #define USE_SIMPLE_UI_RAMPING_TOGGLE
 
-// allow Aux Config and Strobe Modes in Simple UI
-#define USE_EXTENDED_SIMPLE_UI
+// allow Aux Config, Sunset Timer, and Strobe Modes in Simple UI
+#define USE_EXTENDED_SIMPLE_UI 2
 
 // stop panicking at ~75% power or ~3000 lm, this light has high thermal mass
 #define THERM_FASTER_LEVEL (RAMP_SIZE*9/10)  // throttle back faster when high

--- a/hw/sofirn/blf-q8/anduril.h
+++ b/hw/sofirn/blf-q8/anduril.h
@@ -48,7 +48,9 @@
 
 // Allow 3C in Simple UI for switching between smooth and stepped ramping
 #define USE_SIMPLE_UI_RAMPING_TOGGLE
-#define USE_EXTENDED_SIMPLE_UI
+
+// allow Aux Config, Sunset Timer, and Strobe Modes in Simple UI
+#define USE_EXTENDED_SIMPLE_UI 2
 
 // stop panicking at ~75% power or ~3000 lm, this light has high thermal mass
 #define THERM_FASTER_LEVEL (RAMP_SIZE*9/10)  // throttle back faster when high

--- a/hw/wurkkos/anduril.h
+++ b/hw/wurkkos/anduril.h
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
 
-// allow Aux Config and Strobe Modes in Simple UI
-#define USE_EXTENDED_SIMPLE_UI
+// allow Aux Config in Simple UI, but not Sunset Timer or Strobe Modes
+#define USE_EXTENDED_SIMPLE_UI 1
 
 // Allow 3C in Simple UI for switching between smooth and stepped ramping
 #define USE_SIMPLE_UI_RAMPING_TOGGLE

--- a/ui/anduril/lockout-mode.c
+++ b/ui/anduril/lockout-mode.c
@@ -128,13 +128,15 @@ uint8_t lockout_state(Event event, uint16_t arg) {
     }
     #endif
 
-    ////////// Every action below here is blocked in the (non-Extended) Simple UI //////////
+    ////////// Every action below here is blocked in the (non-Extended) Simple UI,
+    ////////// depending on the value of USE_EXTENDED_SIMPLE_UI //////////
 
-    #if defined(USE_SIMPLE_UI) && !defined(USE_EXTENDED_SIMPLE_UI)
+    // If USE_EXTENDED_SIMPLE_UI == 0, block all extended actions
+    #if defined(USE_SIMPLE_UI) && (!defined(USE_EXTENDED_SIMPLE_UI) || USE_EXTENDED_SIMPLE_UI == 0)
     if (cfg.simple_ui_active) {
         return EVENT_NOT_HANDLED;
     }
-    #endif  // if simple UI but not extended simple UI
+    #endif
 
     #if defined(USE_INDICATOR_LED)
     // 7 clicks: rotate through indicator LED modes (lockout mode)
@@ -188,7 +190,7 @@ uint8_t lockout_state(Event event, uint16_t arg) {
     }
     #endif
 
-    #if defined(USE_EXTENDED_SIMPLE_UI) && defined(USE_SIMPLE_UI)
+    #if (defined(USE_EXTENDED_SIMPLE_UI) && USE_EXTENDED_SIMPLE_UI > 0) && defined(USE_SIMPLE_UI)
     ////////// Every action below here is blocked in the Extended Simple UI //////////
     if (cfg.simple_ui_active) {
         return EVENT_NOT_HANDLED;

--- a/ui/anduril/off-mode.c
+++ b/ui/anduril/off-mode.c
@@ -255,7 +255,15 @@ uint8_t off_state(Event event, uint16_t arg) {
         return EVENT_HANDLED;
     }
 
-    ////////// Every action below here is blocked in the (non-Extended) Simple UI //////////
+    ////////// Every action below here is blocked in the (non-Extended) Simple UI, //////////
+    ////////// depending on the value of USE_EXTENDED_SIMPLE_UI //////////
+
+    // If USE_EXTENDED_SIMPLE_UI == 0, block all extended actions
+    #if defined(USE_SIMPLE_UI) && (!defined(USE_EXTENDED_SIMPLE_UI) || USE_EXTENDED_SIMPLE_UI == 0)
+    if (cfg.simple_ui_active) {
+        return EVENT_NOT_HANDLED;
+    }
+    #endif
 
     #ifndef USE_EXTENDED_SIMPLE_UI
     if (cfg.simple_ui_active) {
@@ -263,6 +271,13 @@ uint8_t off_state(Event event, uint16_t arg) {
     }
     #endif  // ifndef USE_EXTENDED_SIMPLE_UI
     #endif  // ifdef USE_SIMPLE_UI
+
+    // If USE_EXTENDED_SIMPLE_UI == 1, allow aux config but block strobes
+    #if defined(USE_SIMPLE_UI) && (USE_EXTENDED_SIMPLE_UI == 1)
+    if (cfg.simple_ui_active) {
+        return EVENT_NOT_HANDLED;
+    }
+    #endif
 
     // click, click, long-click: strobe mode
     #ifdef USE_STROBE_STATE

--- a/ui/anduril/sunset-timer.c
+++ b/ui/anduril/sunset-timer.c
@@ -8,9 +8,12 @@
 
 uint8_t sunset_timer_state(Event event, uint16_t arg) {
 
-    #if defined(USE_SIMPLE_UI) && !defined(USE_EXTENDED_SIMPLE_UI)
-    // No timer functions in Simple UI
-    if (cfg.simple_ui_active) return EVENT_NOT_HANDLED;
+    // No timer functions in (non-extended) Simple UI
+    // If USE_EXTENDED_SIMPLE_UI >= 2, allow sunset timer
+    #if defined(USE_SIMPLE_UI) && (!defined(USE_EXTENDED_SIMPLE_UI) || USE_EXTENDED_SIMPLE_UI <= 1)
+    if (cfg.simple_ui_active) {
+        return EVENT_NOT_HANDLED;
+    }
     #endif
 
     // reset on start


### PR DESCRIPTION
USE_EXTENDED_SIMPLE_UI
0 = (disabled)
1 = aux config
2 = aux config, strobes, sunset timer

May hack on this more and make it more granular, simple UI ramping toggle could also be rolled into this