### PR TITLE
Bugfix: Tactical mode has a dependency on momentary mode

### DIFF
--- a/ui/anduril/anduril.c
+++ b/ui/anduril/anduril.c
@@ -121,7 +121,7 @@
 #include "anduril/lockout-mode.h"
 #endif
 
-#ifdef USE_MOMENTARY_MODE
+#if (defined(USE_MOMENTARY_MODE) || defined(USE_TACTICAL_MODE))
 #include "anduril/momentary-mode.h"
 #endif
 
@@ -189,7 +189,7 @@
 #include "anduril/lockout-mode.c"
 #endif
 
-#ifdef USE_MOMENTARY_MODE
+#if (defined(USE_MOMENTARY_MODE) || defined(USE_TACTICAL_MODE))
 #include "anduril/momentary-mode.c"
 #endif
 

--- a/ui/anduril/strobe-modes.c
+++ b/ui/anduril/strobe-modes.c
@@ -13,7 +13,7 @@ uint8_t strobe_state(Event event, uint16_t arg) {
     // 'st' reduces ROM size slightly
     strobe_mode_te st = current_strobe_type;
 
-    #ifdef USE_MOMENTARY_MODE
+    #if defined(USE_MOMENTARY_MODE) || defined(USE_TACTICAL_MODE)
     momentary_mode = 1;  // 0 = ramping, 1 = strobes
     #endif
 


### PR DESCRIPTION
Use case 1: Updating a t85 light, where tactical mode is useful but takes some squeezing, and momentary is less useful

Use case 2: Custom builds for people who don't like/want momentary mode