### PR TITLE
Bugfix: aux channel modes should use low brightness for level 1 (not off)

### DIFF
--- a/fsm/chan-aux.c
+++ b/fsm/chan-aux.c
@@ -4,7 +4,7 @@
 #pragma once
 
 void set_level_aux(uint8_t level) {
-    indicator_led(!(!(level)) << 1);  // high (or off)
+    indicator_led((!(!(level)) << 1) + 1);  // high (level > 0) or low
 }
 
 bool gradual_tick_null(uint8_t gt) { return true; }  // do nothing

--- a/fsm/chan-rgbaux.c
+++ b/fsm/chan-rgbaux.c
@@ -4,31 +4,31 @@
 #pragma once
 
 void set_level_auxred(uint8_t level) {
-    rgb_led_set(!(!(level)) * 0b000010);  // red, high (or off)
+    rgb_led_set(0b000001 << !(!(level)));  // red, high (level > 0) or low
 }
 
 void set_level_auxyel(uint8_t level) {
-    rgb_led_set(!(!(level)) * 0b001010);  // red+green, high (or off)
+    rgb_led_set(0b000101 << !(!(level)));  // red+green, high (level > 0) or low
 }
 
 void set_level_auxgrn(uint8_t level) {
-    rgb_led_set(!(!(level)) * 0b001000);  // green, high (or off)
+    rgb_led_set(0b000100 << !(!(level)));  // green, high (level > 0) or low
 }
 
 void set_level_auxcyn(uint8_t level) {
-    rgb_led_set(!(!(level)) * 0b101000);  // green+blue, high (or off)
+    rgb_led_set(0b010100 << !(!(level)));  // green+blue, high (level > 0) or low
 }
 
 void set_level_auxblu(uint8_t level) {
-    rgb_led_set(!(!(level)) * 0b100000);  // blue, high (or off)
+    rgb_led_set(0b010000 << !(!(level)));  // blue, high (level > 0) or low
 }
 
 void set_level_auxprp(uint8_t level) {
-    rgb_led_set(!(!(level)) * 0b100010);  // red+blue, high (or off)
+    rgb_led_set(0b010001 << !(!(level)));  // red+blue, high (level > 0) or low
 }
 
 void set_level_auxwht(uint8_t level) {
-    rgb_led_set(!(!(level)) * 0b101010);  // red+green+blue, high (or off)
+    rgb_led_set(0b010101 << !(!(level)));  // red+green+blue, high (level > 0) or low
 }
 
 bool gradual_tick_null(uint8_t gt) { return true; }  // do nothing


### PR DESCRIPTION
In the current implementation of using aux LEDs as channels, level 1 (the lowest level) results in the aux being set to "off" while higher levels result in the aux set to "high".

With this change, level 1 will result in aux "low" while higher levels continue to result in aux "high".

This makes the chan-aux and chan-rgbaux feature slightly more useful. Fixes #65 , also fixes #62.

## Testing
* ts10 v1 (single aux): low aux works for the aux channel at level 1
* ts10 v2 (rgb aux): low aux works for all channels (R, R+G, G, G+B, B, R+B, R+G+B) at level 1