### PR TITLE
New feature: Select previous channel mode with 4C, optionally instead of 4C ramp -> lock

### DIFF
--- a/docs/anduril-manual.md
+++ b/docs/anduril-manual.md
@@ -239,7 +239,9 @@ While the light is on, a few actions are available:
   - `3H`: Tint ramping (only when current channel has adjustable tint).
   - `4H`: Momentary turbo, when `3H` is mapped to tint.
 
-  - `4C`: Go to lockout mode.
+  - `4C`: Go to lockout mode. On some lights with multiple channel modes, this
+          can instead be configured to select the previous channel. See 10H for
+          details.
 
   - `5C`: Go to momentary mode.
   - `5H`: Start a sunset timer.  Details are below in the Sunset Timer section.
@@ -274,6 +276,10 @@ While the light is on, a few actions are available:
     - Item 5: Configure "smooth steps".  
               0: Disable smooth steps.  
               1: Enable smooth steps.
+    - Item 6: Configure the function of 4C when in ramp mode (only on lights
+              with more than one defined channel mode)
+              0: 4C switches off the light and enters lockout mode.
+              1: 4C selects the previous channel mode.
 
 Memory determines which brightness level the light goes to with 1 click
 from off.  There are three types of brightness memory to choose from:

--- a/hw/hank/emisar-2ch/anduril.h
+++ b/hw/hank/emisar-2ch/anduril.h
@@ -99,3 +99,4 @@
 #undef BLINK_AT_RAMP_MIDDLE
 #endif
 
+#define USE_PREVIOUS_CHANNEL

--- a/hw/hank/noctigon-k9.3/anduril.h
+++ b/hw/hank/noctigon-k9.3/anduril.h
@@ -107,3 +107,4 @@
 #undef BLINK_AT_RAMP_MIDDLE
 #endif
 
+#define USE_PREVIOUS_CHANNEL

--- a/hw/hank/noctigon-m44/anduril.h
+++ b/hw/hank/noctigon-m44/anduril.h
@@ -130,3 +130,4 @@
 // for consistency with KR4 (not otherwise necessary though)
 #define USE_SOFT_FACTORY_RESET
 
+#define USE_PREVIOUS_CHANNEL

--- a/ui/anduril/load-save-config-fsm.h
+++ b/ui/anduril/load-save-config-fsm.h
@@ -55,6 +55,10 @@ typedef struct Config {
         #ifdef DEFAULT_BLINK_CHANNEL
             uint8_t blink_channel;
         #endif
+
+        #if (defined(USE_PREVIOUS_CHANNEL) && !defined(PREVIOUS_CHANNEL_REPLACES_LOCKOUT))
+            uint8_t previous_channel_enabled;
+        #endif
     #endif
     #ifdef USE_CHANNEL_MODE_ARGS
         // this is an array, needs a few bytes

--- a/ui/anduril/load-save-config.h
+++ b/ui/anduril/load-save-config.h
@@ -83,6 +83,9 @@ Config cfg = {
             // blink numbers in a specific channel (user configurable)
             .blink_channel = DEFAULT_BLINK_CHANNEL,
         #endif
+        #if (defined(USE_PREVIOUS_CHANNEL) && !defined(PREVIOUS_CHANNEL_REPLACES_LOCKOUT))
+            .previous_channel_enabled = 0,
+        #endif
     #endif
     #ifdef USE_CHANNEL_MODE_ARGS
         // one byte of extra data per channel mode, like for tint value

--- a/ui/anduril/ramp-mode.c
+++ b/ui/anduril/ramp-mode.c
@@ -141,20 +141,17 @@ uint8_t steady_state(Event event, uint16_t arg) {
         return EVENT_HANDLED;
     }
 
-    #ifdef USE_LOCKOUT_MODE
+    #if defined(USE_LOCKOUT_MODE) && !defined(PREVIOUS_CHANNEL_REPLACES_LOCKOUT)
     #ifdef USE_PREVIOUS_CHANNEL
-    #ifndef PREVIOUS_CHANNEL_REPLACES_LOCKOUT //don't include this code at all if we're forcing overriding this shortcut
-    // 4 clicks: shortcut to lockout mode
     else if ((event == EV_4clicks) && (!cfg.previous_channel_enabled))
     #else
     else if (event == EV_4clicks)
-    #endif //ifndef PREVIOUS_CHANNEL_REPLACES_LOCKOUT
+    #endif //ifdef USE_PREVIOUS_CHANNEL
     {
         set_level(0);
         set_state(lockout_state, 0);
         return EVENT_HANDLED;
     }
-    #endif //ifdef USE_PREVIOUS_CHANNEL
     #endif //ifdef USE_LOCKOUT_MODE
 
     // hold: change brightness (brighter, dimmer)

--- a/ui/anduril/ramp-mode.c
+++ b/ui/anduril/ramp-mode.c
@@ -142,13 +142,20 @@ uint8_t steady_state(Event event, uint16_t arg) {
     }
 
     #ifdef USE_LOCKOUT_MODE
+    #ifdef USE_PREVIOUS_CHANNEL
+    #ifndef PREVIOUS_CHANNEL_REPLACES_LOCKOUT //don't include this code at all if we're forcing overriding this shortcut
     // 4 clicks: shortcut to lockout mode
-    else if (event == EV_4clicks) {
+    else if ((event == EV_4clicks) && (!cfg.previous_channel_enabled))
+    #else
+    else if (event == EV_4clicks)
+    #endif //ifndef PREVIOUS_CHANNEL_REPLACES_LOCKOUT
+    {
         set_level(0);
         set_state(lockout_state, 0);
         return EVENT_HANDLED;
     }
-    #endif
+    #endif //ifdef USE_PREVIOUS_CHANNEL
+    #endif //ifdef USE_LOCKOUT_MODE
 
     // hold: change brightness (brighter, dimmer)
     // click, hold: change brightness (dimmer)
@@ -612,6 +619,13 @@ void ramp_extras_config_save(uint8_t step, uint8_t value) {
         cfg.smooth_steps_style = value;
     }
     #endif
+
+    #if (defined(USE_PREVIOUS_CHANNEL) && !defined(PREVIOUS_CHANNEL_REPLACES_LOCKOUT))
+    else if (previous_channel_enabled_config_step == step) {
+        cfg.previous_channel_enabled = value;
+    }
+    #endif
+
 }
 
 uint8_t ramp_extras_config_state(Event event, uint16_t arg) {

--- a/ui/anduril/ramp-mode.h
+++ b/ui/anduril/ramp-mode.h
@@ -203,6 +203,9 @@ typedef enum {
     #ifdef USE_SMOOTH_STEPS
     smooth_steps_style_config_step,
     #endif
+    #if (defined(USE_PREVIOUS_CHANNEL) && !defined(PREVIOUS_CHANNEL_REPLACES_LOCKOUT))
+    previous_channel_enabled_config_step,
+    #endif
     ramp_extras_config_num_steps
 } ramp_extras_config_steps_e;
 #endif


### PR DESCRIPTION
Two options. Previous channel is on 4C from ramp mode only and replaces lockout mode from ramp when enabled.

By defining `USE_PREVIOUS_CHANNEL` it is included as a configurable option under the ramp extras menu (0: 4C -> lock. 1: 4C -> previous channel). By defining both `USE_PREVIOUS_CHANNEL` and `PREVIOUS_CHANNEL_REPLACES_LOCKOUT` the lockout shortcut is entirely removed and the runtime config option is not included to save some space.