### PR TITLE
Added construction mode to strobe

### DIFF
--- a/ui/anduril/strobe-modes-fsm.h
+++ b/ui/anduril/strobe-modes-fsm.h
@@ -37,6 +37,9 @@ typedef enum {
     #ifdef USE_POLICE_COLOR_STROBE_MODE
     police_color_strobe_e,
     #endif
+    #ifdef USE_CONSTRUCTION_COLOR_STROBE_MODE
+    construction_color_strobe_e,
+    #endif
     #ifdef USE_LIGHTNING_MODE
     lightning_storm_e,
     #endif

--- a/ui/anduril/strobe-modes.c
+++ b/ui/anduril/strobe-modes.c
@@ -184,9 +184,14 @@ inline void strobe_state_iter() {
             break;
         #endif
 
-        #ifdef USE_POLICE_COLOR_STROBE_MODE
+        #if defined(USE_POLICE_COLOR_STROBE_MODE) || defined(USE_CONSTRUCTION_COLOR_STROBE_MODE)
+        #ifdef USE_CONSTRUCTION_COLOR_STROBE_MODE
+        case construction_color_strobe_e:
+        #endif
+        #ifdef USE_CONSTRUCTION_COLOR_STROBE_MODE
         case police_color_strobe_e:
-            police_color_strobe_iter();
+            police_construction_color_strobe_iter(st);
+        #endif
             break;
         #endif
 
@@ -232,8 +237,8 @@ inline void party_tactical_strobe_mode_iter(uint8_t st) {
 }
 #endif
 
-#ifdef USE_POLICE_COLOR_STROBE_MODE
-inline void police_color_strobe_iter() {
+#if defined(USE_POLICE_COLOR_STROBE_MODE) || defined(USE_CONSTRUCTION_COLOR_STROBE_MODE)
+inline void police_construction_color_strobe_iter(uint8_t st) {
     // one iteration of main loop()
     uint8_t del = 66;
     // TODO: make police strobe brightness configurable
@@ -241,8 +246,28 @@ inline void police_color_strobe_iter() {
     //uint8_t channel = channel_mode;
 
     for (uint8_t i=0; i<10; i++) {
-        if (0 == i) set_channel_mode(POLICE_COLOR_STROBE_CH1);
-        else if (5 == i) set_channel_mode(POLICE_COLOR_STROBE_CH2);
+        if (0 == i) {
+	    if (0){} //placeholder
+	    #ifdef USE_CONSTRUCTION_COLOR_STROBE_MODE
+	    else if (st == construction_color_strobe_e)
+                set_channel_mode(CONSTRUCTION_COLOR_STROBE_CH1);
+            #endif
+	    #ifdef USE_POLICE_COLOR_STROBE_MODE
+	    else
+                set_channel_mode(POLICE_COLOR_STROBE_CH1);
+            #endif
+	}
+        else if (5 == i) {
+	    if (0){} //placeholder
+	    #ifdef USE_CONSTRUCTION_COLOR_STROBE_MODE
+	    else if (st == construction_color_strobe_e)
+	        set_channel_mode(CONSTRUCTION_COLOR_STROBE_CH2);
+            #endif
+	    #ifdef USE_POLICE_COLOR_STROBE_MODE
+	    else
+                set_channel_mode(POLICE_COLOR_STROBE_CH2);
+            #endif
+	}
         set_level(bright);
         nice_delay_ms(del >> 1);
         set_level(STROBE_OFF_LEVEL);

--- a/ui/anduril/strobe-modes.h
+++ b/ui/anduril/strobe-modes.h
@@ -45,8 +45,8 @@ inline void strobe_state_iter();
 inline void party_tactical_strobe_mode_iter(uint8_t st);
 #endif
 
-#ifdef USE_POLICE_COLOR_STROBE_MODE
-inline void police_color_strobe_iter();
+#if defined(USE_POLICE_COLOR_STROBE_MODE) || defined(USE_CONSTRUCTION_COLOR_STROBE_MODE)
+inline void police_construction_color_strobe_iter(uint8_t st);
 #endif
 
 #ifdef USE_LIGHTNING_MODE


### PR DESCRIPTION
I am not thrilled with this.  It didn't turn out well due to the available aux colors. The feature works and hopefully someday there are better color options for this.  Since it didn't turn out well, I didn't add it to any hardware so it doesn't affect anything.  It can be added to hw anduril.h files like so:

// use aux white + aux yellow for construction strobe
#define USE_CONSTRUCTION_COLOR_STROBE_MODE
#define CONSTRUCTION_COLOR_STROBE_CH1  CM_AUXYEL
#define CONSTRUCTION_COLOR_STROBE_CH2  CM_AUXWHT

Maybe when I have newer avr lights I will come back to this.

closes #60 