### PR TITLE
Add default handlers for thermal regulation

### DIFF
--- a/fsm/events.c
+++ b/fsm/events.c
@@ -44,11 +44,11 @@ uint8_t emit_now(Event event, uint16_t arg) {
     for(int8_t i=state_stack_len-1; i>=0; i--) {
         uint8_t err = state_stack[i](event, arg);
         if (! err) {
-#ifndef DONT_USE_DEFAULT_STATE
+            #ifndef DONT_USE_DEFAULT_STATE
             // Always allow default state to handle EV_tick events
             if (event == EV_tick && state_stack[i] != default_state)
                 default_state(event, arg);
-#endif
+            #endif
             return 0;
         }
     }

--- a/fsm/events.c
+++ b/fsm/events.c
@@ -43,7 +43,14 @@ void process_emissions() {
 uint8_t emit_now(Event event, uint16_t arg) {
     for(int8_t i=state_stack_len-1; i>=0; i--) {
         uint8_t err = state_stack[i](event, arg);
-        if (! err) return 0;
+        if (! err) {
+#ifndef DONT_USE_DEFAULT_STATE
+            // Always allow default state to handle EV_tick events
+            if (event == EV_tick && state_stack[i] != default_state)
+                default_state(event, arg);
+#endif
+            return 0;
+        }
     }
     return 1;  // event not handled
 }

--- a/fsm/ramping.c
+++ b/fsm/ramping.c
@@ -68,9 +68,9 @@ inline void set_ceiling_level(uint8_t level) {
 }
 
 inline void reset_ceiling_level() {
-#ifdef USE_SET_LEVEL_GRADUALLY
+    #ifdef USE_SET_LEVEL_GRADUALLY
     set_ceiling_level_gradually(UINT8_MAX);
-#endif
+    #endif
     set_ceiling_level(UINT8_MAX);
 }
 

--- a/fsm/ramping.c
+++ b/fsm/ramping.c
@@ -67,6 +67,13 @@ inline void set_ceiling_level(uint8_t level) {
     }
 }
 
+inline void reset_ceiling_level() {
+#ifdef USE_SET_LEVEL_GRADUALLY
+    set_ceiling_level_gradually(UINT8_MAX);
+#endif
+    set_ceiling_level(UINT8_MAX);
+}
+
 #ifdef USE_SET_LEVEL_GRADUALLY
 inline void set_ceiling_level_gradually(uint8_t level) {
     if (level == 0)

--- a/fsm/ramping.c
+++ b/fsm/ramping.c
@@ -55,12 +55,33 @@ inline void set_level_aux_rgb_leds(uint8_t level) {
 }
 #endif  // ifdef USE_AUX_RGB_LEDS_WHILE_ON
 
+#if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
+	&& defined(USE_DEFAULT_THERMAL_REGULATION)
+inline void set_ceiling_level(uint8_t level) {
+    if (level == 0)
+        level = 1;
+    // Set new ceiling
+    if (level != ceiling_level) {
+        ceiling_level = level;
+        set_level(ceiling_target_level);
+    }
+}
+#endif
 
 void set_level(uint8_t level) {
     #ifdef USE_RAMP_LEVEL_HARD_LIMIT
     if (ramp_level_hard_limit && (level > ramp_level_hard_limit))
         level = ramp_level_hard_limit;
     #endif
+
+    #if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
+        && defined(USE_DEFAULT_THERMAL_REGULATION)
+	// Save target level so that it can be restored if the ceiling is raised
+	ceiling_target_level = level;
+	// Limit level to current ceiling
+	if(level > ceiling_level)
+		level = ceiling_level;
+	#endif
 
     #ifdef USE_JUMP_START
     // maybe "jump start" the engine, if it's prone to slow starts

--- a/fsm/ramping.c
+++ b/fsm/ramping.c
@@ -66,6 +66,23 @@ inline void set_ceiling_level(uint8_t level) {
         set_level(ceiling_target_level);
     }
 }
+
+#ifdef USE_SET_LEVEL_GRADUALLY
+inline void set_ceiling_level_gradually(uint8_t level) {
+    if (level == 0)
+        level = 1;
+    // Set new gradual ceiling target to approch per tick
+    ceiling_gradual_level = level;
+}
+
+inline void ceiling_gradual_tick() {
+    // Move ceiling level towards gradual level
+    if (ceiling_level > ceiling_gradual_level)
+        set_ceiling_level(ceiling_level - 1);
+    else if (ceiling_level < ceiling_gradual_level)
+        set_ceiling_level(ceiling_level + 1);
+}
+#endif
 #endif
 
 void set_level(uint8_t level) {

--- a/fsm/ramping.h
+++ b/fsm/ramping.h
@@ -23,6 +23,11 @@ void set_level_zero();  // implement this in a hwdef
 uint8_t ceiling_level = UINT8_MAX;
 uint8_t ceiling_target_level = 0;
 inline void set_ceiling_level(uint8_t level);
+#ifdef USE_SET_LEVEL_GRADUALLY
+uint8_t ceiling_gradual_level = UINT8_MAX;
+inline void set_ceiling_level_gradually(uint8_t level);
+inline void ceiling_gradual_tick();
+#endif
 #endif
 
 #ifdef USE_SET_LEVEL_GRADUALLY

--- a/fsm/ramping.h
+++ b/fsm/ramping.h
@@ -23,6 +23,7 @@ void set_level_zero();  // implement this in a hwdef
 uint8_t ceiling_level = UINT8_MAX;
 uint8_t ceiling_target_level = 0;
 inline void set_ceiling_level(uint8_t level);
+inline void reset_ceiling_level();
 #ifdef USE_SET_LEVEL_GRADUALLY
 uint8_t ceiling_gradual_level = UINT8_MAX;
 inline void set_ceiling_level_gradually(uint8_t level);

--- a/fsm/ramping.h
+++ b/fsm/ramping.h
@@ -18,6 +18,13 @@ void set_level(uint8_t level);
 //void set_level_smooth(uint8_t level);
 void set_level_zero();  // implement this in a hwdef
 
+#if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
+	&& defined(USE_DEFAULT_THERMAL_REGULATION)
+uint8_t ceiling_level = UINT8_MAX;
+uint8_t ceiling_target_level = 0;
+inline void set_ceiling_level(uint8_t level);
+#endif
+
 #ifdef USE_SET_LEVEL_GRADUALLY
 // adjust brightness very smoothly
 uint8_t gradual_target;

--- a/fsm/states.c
+++ b/fsm/states.c
@@ -94,6 +94,18 @@ uint8_t default_state(Event event, uint16_t arg) {
         low_temperature(arg);
         return EVENT_HANDLED;
     }
+
+    #ifdef USE_SET_LEVEL_GRADUALLY
+    else if (event == EV_temperature_okay) {
+        okay_temperature();
+        return EVENT_HANDLED;
+    }
+
+    else if (event == EV_tick) {
+        default_tick();
+        return EVENT_HANDLED;
+    }
+    #endif
     #endif
 
     // event not handled

--- a/fsm/states.c
+++ b/fsm/states.c
@@ -84,18 +84,16 @@ uint8_t default_state(Event event, uint16_t arg) {
     }
     #endif
 
-    #if 0
-    #ifdef USE_THERMAL_REGULATION
+    #if defined(USE_THERMAL_REGULATION) && defined(USE_DEFAULT_THERMAL_REGULATION)
     else if (event == EV_temperature_high) {
-        high_temperature();
-        return 0;
+        high_temperature(arg);
+        return EVENT_HANDLED;
     }
 
     else if (event == EV_temperature_low) {
-        low_temperature();
-        return 0;
+        low_temperature(arg);
+        return EVENT_HANDLED;
     }
-    #endif
     #endif
 
     // event not handled

--- a/fsm/states.h
+++ b/fsm/states.h
@@ -37,6 +37,10 @@ uint8_t default_state(Event event, uint16_t arg);
 #if defined(USE_THERMAL_REGULATION) && defined(USE_DEFAULT_THERMAL_REGULATION)
 void high_temperature(uint16_t howmuch);
 void low_temperature(uint16_t howmuch);
+#ifdef USE_SET_LEVEL_GRADUALLY
+void okay_temperature();
+void default_tick();
+#endif
 #endif
 #endif
 

--- a/fsm/states.h
+++ b/fsm/states.h
@@ -33,5 +33,10 @@ void set_state_deferred(StatePtr new_state, uint16_t arg);
 
 #ifndef DONT_USE_DEFAULT_STATE
 uint8_t default_state(Event event, uint16_t arg);
+
+#if defined(USE_THERMAL_REGULATION) && defined(USE_DEFAULT_THERMAL_REGULATION)
+void high_temperature(uint16_t howmuch);
+void low_temperature(uint16_t howmuch);
+#endif
 #endif
 

--- a/ui/anduril/anduril.c
+++ b/ui/anduril/anduril.c
@@ -285,6 +285,16 @@ void loop() {
     // "current_state" is volatile, so cache it to reduce code size
     StatePtr state = current_state;
 
+	#if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
+        && defined(USE_DEFAULT_THERMAL_REGULATION)
+    static StatePtr last_state = NULL;
+    if(state != last_state) {
+        // Reset ceiling when switching state
+        reset_ceiling_level();
+        last_state = state;
+    }
+    #endif
+
     #ifdef USE_AUX_RGB_LEDS_WHILE_ON
     // display battery charge on RGB button during use
     if (state == steady_state)

--- a/ui/anduril/anduril.c
+++ b/ui/anduril/anduril.c
@@ -427,7 +427,11 @@ inline void high_temperature(uint16_t howmuch) {
     int16_t stepdown = ceiling_level - howmuch;
     if (stepdown < MIN_THERM_STEPDOWN) stepdown = MIN_THERM_STEPDOWN;
     else if (stepdown > MAX_LEVEL) stepdown = MAX_LEVEL;
+    #ifdef USE_SET_LEVEL_GRADUALLY
+    set_ceiling_level_gradually(stepdown);
+    #else
     set_ceiling_level(stepdown);
+    #endif
 }
 
 // If EV_temperature_low is not handled by the current mode
@@ -436,7 +440,11 @@ inline void low_temperature(uint16_t howmuch) {
     int16_t stepup = ceiling_level + howmuch;
     if (stepup > MAX_LEVEL) stepup = MAX_LEVEL;
     else if (stepup < MIN_THERM_STEPDOWN) stepup = MIN_THERM_STEPDOWN;
+    #ifdef USE_SET_LEVEL_GRADUALLY
+    set_ceiling_level_gradually(stepup);
+    #else
     set_ceiling_level(stepup);
+    #endif
 }
 #endif
 

--- a/ui/anduril/anduril.c
+++ b/ui/anduril/anduril.c
@@ -409,3 +409,24 @@ void low_voltage() {
 
 }
 
+#if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
+	&& defined(USE_DEFAULT_THERMAL_REGULATION)
+// If EV_temperature_high is not handled by the current mode
+// we handle it here
+inline void high_temperature(uint16_t howmuch) {
+    int16_t stepdown = ceiling_level - howmuch;
+    if (stepdown < MIN_THERM_STEPDOWN) stepdown = MIN_THERM_STEPDOWN;
+    else if (stepdown > MAX_LEVEL) stepdown = MAX_LEVEL;
+    set_ceiling_level(stepdown);
+}
+
+// If EV_temperature_low is not handled by the current mode
+// we handle it here
+inline void low_temperature(uint16_t howmuch) {
+    int16_t stepup = ceiling_level + howmuch;
+    if (stepup > MAX_LEVEL) stepup = MAX_LEVEL;
+    else if (stepup < MIN_THERM_STEPDOWN) stepup = MIN_THERM_STEPDOWN;
+    set_ceiling_level(stepup);
+}
+#endif
+

--- a/ui/anduril/anduril.c
+++ b/ui/anduril/anduril.c
@@ -478,7 +478,8 @@ inline void default_tick(void) {
             ceiling_gradual_tick();
             ticks_since_adjust = 0;
         }
-    }
+    } else
+        ticks_since_adjust = 0;
 }
 #endif
 #endif

--- a/ui/anduril/candle-mode.c
+++ b/ui/anduril/candle-mode.c
@@ -88,7 +88,16 @@ uint8_t candle_mode_state(Event event, uint16_t arg) {
         add = ((triangle_wave(candle_wave1) * candle_wave1_depth) >> 8)
             + ((triangle_wave(candle_wave2) * candle_wave2_depth) >> 8)
             + ((triangle_wave(candle_wave3) * candle_wave3_depth) >> 8);
-        uint16_t brightness = candle_mode_brightness + add;
+        uint16_t brightness = add;
+
+        #if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
+            && defined(USE_DEFAULT_THERMAL_REGULATION)
+        // Adjust brightness to allow full amplitude to stay below ceiling
+        if (candle_mode_brightness + CANDLE_AMPLITUDE > ceiling_level)
+            brightness += ceiling_level > CANDLE_AMPLITUDE ? ceiling_level - CANDLE_AMPLITUDE : ceiling_level;
+        else
+        #endif
+        brightness += candle_mode_brightness;
 
         // self-timer dims the light during the final minute
         #ifdef USE_SUNSET_TIMER

--- a/ui/anduril/config-default.h
+++ b/ui/anduril/config-default.h
@@ -42,7 +42,9 @@
 #define USE_THERM_AUTOCALIBRATE
 
 // Enable thermal regulation in default state if unhandled by current mode
-#undef USE_DEFAULT_THERMAL_REGULATION
+#if ROM_SIZE > 10000
+#define USE_DEFAULT_THERMAL_REGULATION
+#endif
 
 // Include a simplified UI for non-enthusiasts?
 #define USE_SIMPLE_UI

--- a/ui/anduril/config-default.h
+++ b/ui/anduril/config-default.h
@@ -41,6 +41,9 @@
 // (include THERM_CAL_OFFSET in sum as it might already be a non-zero number)
 #define USE_THERM_AUTOCALIBRATE
 
+// Enable thermal regulation in default state if unhandled by current mode
+#undef USE_DEFAULT_THERMAL_REGULATION
+
 // Include a simplified UI for non-enthusiasts?
 #define USE_SIMPLE_UI
 

--- a/ui/anduril/ramp-mode.c
+++ b/ui/anduril/ramp-mode.c
@@ -93,6 +93,12 @@ uint8_t steady_state(Event event, uint16_t arg) {
 
     // turn LED on when we first enter the mode
     if ((event == EV_enter_state) || (event == EV_reenter_state)) {
+        #if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
+            && defined(USE_DEFAULT_THERMAL_REGULATION)
+        // Remove thermal ceiling as we do our own regulation in this state
+        set_ceiling_level(UINT8_MAX);
+        #endif
+
         #if defined(USE_MOMENTARY_MODE) && defined(USE_STROBE_STATE)
         momentary_mode = 0;  // 0 = ramping, 1 = strobes
         #endif

--- a/ui/anduril/ramp-mode.c
+++ b/ui/anduril/ramp-mode.c
@@ -93,12 +93,6 @@ uint8_t steady_state(Event event, uint16_t arg) {
 
     // turn LED on when we first enter the mode
     if ((event == EV_enter_state) || (event == EV_reenter_state)) {
-        #if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
-            && defined(USE_DEFAULT_THERMAL_REGULATION)
-        // Remove thermal ceiling as we do our own regulation in this state
-        set_ceiling_level(UINT8_MAX);
-        #endif
-
         #if defined(USE_MOMENTARY_MODE) && defined(USE_STROBE_STATE)
         momentary_mode = 0;  // 0 = ramping, 1 = strobes
         #endif

--- a/ui/anduril/strobe-modes.c
+++ b/ui/anduril/strobe-modes.c
@@ -326,9 +326,8 @@ inline void bike_flasher_iter() {
     uint8_t brightness = cfg.bike_flasher_brightness;
     #if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
         && defined(USE_DEFAULT_THERMAL_REGULATION)
-    #define MAX_BIKING_DIFF (MAX_LEVEL - MAX_BIKING_LEVEL)
-    if (brightness + MAX_BIKING_LEVEL > ceiling_level)
-        brightness = ceiling_level - MAX_BIKING_LEVEL;
+    if (brightness > (ceiling_level >> 1))
+        brightness = ceiling_level >> 1;
     #endif
     uint8_t burst = brightness << 1;
     if (burst > MAX_LEVEL) burst = MAX_LEVEL;

--- a/ui/anduril/strobe-modes.c
+++ b/ui/anduril/strobe-modes.c
@@ -323,12 +323,19 @@ inline void lightning_storm_iter() {
 #endif
 inline void bike_flasher_iter() {
     // one iteration of main loop()
-    uint8_t burst = cfg.bike_flasher_brightness << 1;
+    uint8_t brightness = cfg.bike_flasher_brightness;
+    #if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
+        && defined(USE_DEFAULT_THERMAL_REGULATION)
+    #define MAX_BIKING_DIFF (MAX_LEVEL - MAX_BIKING_LEVEL)
+    if (brightness + MAX_BIKING_LEVEL > ceiling_level)
+        brightness = ceiling_level - MAX_BIKING_LEVEL;
+    #endif
+    uint8_t burst = brightness << 1;
     if (burst > MAX_LEVEL) burst = MAX_LEVEL;
     for(uint8_t i=0; i<4; i++) {
         set_level(burst);
         nice_delay_ms(5 + BIKE_STROBE_ONTIME);
-        set_level(cfg.bike_flasher_brightness);
+        set_level(brightness);
         nice_delay_ms(65);
     }
     nice_delay_ms(720);  // no return check necessary on final delay

--- a/ui/anduril/strobe-modes.c
+++ b/ui/anduril/strobe-modes.c
@@ -41,6 +41,11 @@ uint8_t strobe_state(Event event, uint16_t arg) {
     else if (event == EV_2clicks) {
         current_strobe_type = cfg.strobe_type = (st + 1) % NUM_STROBES;
         save_config();
+        #if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
+            && defined(USE_DEFAULT_THERMAL_REGULATION)
+        // Reset ceiling when switching mode
+        reset_ceiling_level();
+        #endif
         return EVENT_HANDLED;
     }
     #if (NUM_CHANNEL_MODES > 1) && defined(USE_CHANNEL_PER_STROBE)
@@ -50,6 +55,11 @@ uint8_t strobe_state(Event event, uint16_t arg) {
         set_channel_mode((channel_mode + 1) % NUM_CHANNEL_MODES);
         cfg.strobe_channels[st] = channel_mode;
         save_config();
+        #if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
+            && defined(USE_DEFAULT_THERMAL_REGULATION)
+        // Reset ceiling when switching mode
+        reset_ceiling_level();
+        #endif
         return EVENT_HANDLED;
     }
     #endif
@@ -57,6 +67,11 @@ uint8_t strobe_state(Event event, uint16_t arg) {
     else if (event == EV_4clicks) {
         current_strobe_type = cfg.strobe_type = (st - 1 + NUM_STROBES) % NUM_STROBES;
         save_config();
+        #if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
+            && defined(USE_DEFAULT_THERMAL_REGULATION)
+        // Reset ceiling when switching mode
+        reset_ceiling_level();
+        #endif
         return EVENT_HANDLED;
     }
     // hold: change speed (go faster)

--- a/ui/anduril/strobe-modes.c
+++ b/ui/anduril/strobe-modes.c
@@ -326,7 +326,10 @@ inline void bike_flasher_iter() {
     uint8_t brightness = cfg.bike_flasher_brightness;
     #if !defined(DONT_USE_DEFAULT_STATE) && defined(USE_THERMAL_REGULATION) \
         && defined(USE_DEFAULT_THERMAL_REGULATION)
-    if (brightness > (ceiling_level >> 1))
+    #define MAX_BIKING_DIFF (MAX_LEVEL - MAX_BIKING_LEVEL)
+    if (ceiling_level > MAX_BIKING_DIFF && brightness > ceiling_level - MAX_BIKING_DIFF)
+        brightness = ceiling_level - MAX_BIKING_DIFF;
+    else if (brightness > ceiling_level)
         brightness = ceiling_level >> 1;
     #endif
     uint8_t burst = brightness << 1;


### PR DESCRIPTION
Adds default handlers for `EV_temperature_high` and `EV_temperature_low` to provide thermal regulation in modes that do not handle it themselves (e.g. strobe/mood modes).
Thermal regulation is done is done by adjusting a ceiling level that caps the requested output level. If the ceiling is raised, the output level will also be raised if possible: The logic is basically the same as in ramp mode except a ceiling is adjusted rather than the current level. In ramp mode, the thermal regulation is unchanged.

Only enabled when `DONT_USE_DEFAULT_STATE` is undefined, `USE_THERMAL_REGULATION` and `USE_DEFAULT_THERMAL_REGULATION` as I know some users do not want any thermal stepdown in strobe modes.

Candle mode brightness is also automatically adjusted when thermally capped to not cut off mid-amplitude as that may look ugly.