### PR TITLE
Enable use of USE_INDICATOR_LED with a fw3x-lume1 driver

### DIFF
--- a/fsm/misc.c
+++ b/fsm/misc.c
@@ -148,7 +148,40 @@ void indicator_led(uint8_t lvl) {
             #endif
             break;
 
-        #else  // MCU is old tiny style, not newer mega style
+        #elif (MCU==0x1634)  // for ATTINY1634 with a single AUX channel connected to one pin on a lume1 driver
+
+        case 0:  // indicator off
+            DDRA &= 0xff ^ (1 << AUXLED_PIN);
+            PUEA &= 0xff ^ (1 << AUXLED_PIN);
+            PORTA &= 0xff ^ (1 << AUXLED_PIN);
+            #ifdef AUXLED2_PIN  // second LED mirrors the first
+            DDRA &= 0xff ^ (1 << AUXLED2_PIN);
+            PUEA &= 0xff ^ (1 << AUXLED2_PIN);
+            PORTA &= 0xff ^ (1 << AUXLED2_PIN);
+            #endif
+            break;
+        case 1:  // indicator low
+            DDRA &= 0xff ^ (1 << AUXLED_PIN);
+            PUEA |= (1 << AUXLED_PIN);
+            PORTA |= (1 << AUXLED_PIN);
+            #ifdef AUXLED2_PIN  // second LED mirrors the first
+            DDRA &= 0xff ^ (1 << AUXLED2_PIN);
+            PUEA |= (1 << AUXLED2_PIN);
+            PORTA |= (1 << AUXLED2_PIN);
+            #endif
+            break;
+        default:  // indicator high
+            DDRA |= (1 << AUXLED_PIN);
+            PUEA |= (1 << AUXLED_PIN);
+            PORTA |= (1 << AUXLED_PIN);
+            #ifdef AUXLED2_PIN  // second LED mirrors the first
+            DDRA |= (1 << AUXLED2_PIN);
+            PUEA |= (1 << AUXLED2_PIN);
+            PORTA |= (1 << AUXLED2_PIN);
+            #endif
+            break;
+
+        #else  // MCU is old tiny style, not newer mega style nor is it ATTINY1634
 
         case 0:  // indicator off
             DDRB &= 0xff ^ (1 << AUXLED_PIN);
@@ -174,7 +207,7 @@ void indicator_led(uint8_t lvl) {
             PORTB |= (1 << AUXLED2_PIN);
             #endif
             break;
-
+            
         #endif  // MCU type
     }
 }


### PR DESCRIPTION
Swapping in a lume1 driver is a popular mod for FW3A flashlights, especially in combination with a lume AUX board.

Sometimes, a clumsy modder damages one or more of the R, G, B connector pads on the lume1 driver so that 3-colour AUX can no longer be used. Instead, such a clumsy modder would like to use the damaged lume1 driver in a single-colour AUX configuration, so as not to waste it. This should be achievable by replacing `#define USE_AUX_RGB_LEDS` with `#define USE_INDICATOR_LED` in a custom `anduril.h`.

However, clumsy modders weren't considered in `fsm/misc.c', so that single-colour AUX isn't considered for the ATTINY1634 MCU used on the lume1 AUX board.

This PR enables the use of `USE_INDICATOR_LED` with the ATTINY1634 MCU so that clumsy modders may rejoice.

Some discussion of this (including how to then use `USE_INDICATOR_LED` for the lume1 driver) is here: [click](https://budgetlightforum.com/t/custom-anduril-2-fw3x-lume1-build-help-with-device-configuration-changes/222961)