### PR TITLE
d3aa: Fix D3AA build without party strobe enabled

### DIFF
--- a/hw/hank/emisar-d3aa/anduril.h
+++ b/hw/hank/emisar-d3aa/anduril.h
@@ -107,6 +107,7 @@
 
 // Misc
 
+#define USE_DELAY_ZERO  // needed for detect_weak_battery
 #define PARTY_STROBE_ONTIME 1  // slow down party strobe
 #define STROBE_OFF_LEVEL 1  // keep the regulator chip on between pulses
 

--- a/ui/anduril/config-default.h
+++ b/ui/anduril/config-default.h
@@ -215,3 +215,10 @@
 // (but allow disabling this feature per build)
 #define USE_CHANNEL_PER_STROBE
 
+// if weak battery detection is enabled, this needs delay_zero
+#ifdef USE_WEAK_BATTERY_PROTECTION
+#ifndef USE_DELAY_ZERO
+#define USE_DELAY_ZERO
+#endif
+#endif
+


### PR DESCRIPTION
Fix the D3AA build without party strobe enabled, or some other function that defines `USE_DELAY_ZERO`.

Building Anduril for D3AA with party strobe disabled removes the only dependency that defines the `delay_zero()` function, which is used by the weak battery detection feature. This leads to an implicit function declaration and eventually a build break with an undefined symbol. Adding a definition to `anduril.h` resolves the issue and allows building normally.

Tested to build and run on Emisar D3AA.