### PR TITLE
Bugfix (#69): tint_ramp_direction does not get reset when channel mode arg is changed by manual memory

### DIFF
--- a/hw/sofirn/blf-lt1/anduril.h
+++ b/hw/sofirn/blf-lt1/anduril.h
@@ -98,6 +98,10 @@
 // party strobe, tac strobe, lightning, candle, bike
 #define DEFAULT_STROBE_CHANNELS  CM_BOTH,CM_BOTH,CM_AUTO,CM_AUTO,CM_AUTO
 
+// FIXME: This light has a known issue (https://github.com/ToyKeeper/anduril/issues/69)
+// but the fix doesn't fit on the t85, so disable it
+#undef USE_TINT_RAMP_DIRECTION_FIX
+
 // for consistency with other models
 #define USE_SOFT_FACTORY_RESET
 

--- a/ui/anduril/channel-modes.c
+++ b/ui/anduril/channel-modes.c
@@ -71,6 +71,19 @@ uint8_t channel_mode_state(Event event, uint16_t arg) {
         if (! arg) {
             active = 1;  // first frame means this is for us
             past_edge_counter = 0;  // doesn't start until user hits the edge
+
+            #ifdef USE_TINT_RAMP_DIRECTION_FIX // doesn't fit on the original LT1
+            // Issue 69: if manual memory was set to an arg of 0 or 255, this could result in an incorrect
+            // ramp direction with the arg resetting, so make sure tint_ramp_direction is set correctly
+            if (channel_has_args(channel_mode)) {
+                if (cfg.channel_mode_args[channel_mode] == 0){
+                    tint_ramp_direction = 1;
+                }
+                else if (cfg.channel_mode_args[channel_mode] == 255){
+                    tint_ramp_direction = -1;
+                }
+            }
+            #endif
         }
         // ignore event if we weren't the ones who handled the first frame
         if (! active) return EVENT_NOT_HANDLED;

--- a/ui/anduril/config-default.h
+++ b/ui/anduril/config-default.h
@@ -215,3 +215,6 @@
 // (but allow disabling this feature per build)
 #define USE_CHANNEL_PER_STROBE
 
+// We want this bugfix on everything except the original t85 LT1 (because it doesn't fit)
+#define USE_TINT_RAMP_DIRECTION_FIX
+


### PR DESCRIPTION
Fixes https://github.com/ToyKeeper/anduril/issues/69 (nice)