### PR TITLE
Avoid overflow of `ticks_since_adjust`.

### DIFF
--- a/ui/anduril/ramp-mode.c
+++ b/ui/anduril/ramp-mode.c
@@ -285,8 +285,8 @@ uint8_t steady_state(Event event, uint16_t arg) {
         #ifdef USE_SET_LEVEL_GRADUALLY
         int16_t diff = gradual_target - actual_level;
         static uint16_t ticks_since_adjust = 0;
-        ticks_since_adjust++;
         if (diff) {
+            ticks_since_adjust++;
             uint16_t ticks_per_adjust = 256 / GRADUAL_ADJUST_SPEED;
             if (diff < 0) {
                 //diff = -diff;
@@ -310,7 +310,8 @@ uint8_t steady_state(Event event, uint16_t arg) {
                 gradual_tick();
                 ticks_since_adjust = 0;
             }
-        }
+        } else
+            ticks_since_adjust = 0;
         #endif  // ifdef USE_SET_LEVEL_GRADUALLY
         return EVENT_HANDLED;
     }


### PR DESCRIPTION
`ticks_since_adjust` may overflow when gradual target matches actual level causing faster or slower adjustment when gradual target changes.