### PR TITLE
arch: attiny1634: Use built-in temperature calibration data

### DIFF
--- a/ui/anduril/config-default.h
+++ b/ui/anduril/config-default.h
@@ -20,7 +20,7 @@
 
 // overheat protection
 #define USE_THERMAL_REGULATION
-#if (MCU==0x85) || (MCU==0x1634)
+#if (MCU==0x85)
 // sloppy temperature sensor needs bigger error margin
 #define DEFAULT_THERM_CEIL 45  // try not to get hotter than this (in C)
 #else


### PR DESCRIPTION
Improves the out of box thermal calibration of all attiny1634 lights by using the factory calibration data in the Device Signature register.

I do not have enough lights to do a large scale test of this one, but the temperature indicated after factory reset is much closer to the correct value on the two lights I tried (Emisar D1 v2 boost and Emisar D4K 2ch), within 2-3 degrees C.