### PR TITLE
Fix issue #107 blocking channel-mode events past 3H on d4k-3ch.

### DIFF
--- a/ui/anduril/channel-modes.c
+++ b/ui/anduril/channel-modes.c
@@ -55,7 +55,8 @@ uint8_t channel_mode_state(Event event, uint16_t arg) {
 
     #ifdef USE_CUSTOM_CHANNEL_3H_MODES
     // defer to mode-specific function if defined
-    else if (channel_3H_modes[channel_mode]) {
+    else if ((event == EV_click3_hold || event == EV_click3_hold_release) &&
+            channel_3H_modes[channel_mode]) {
         StatePtr tint_func = channel_3H_modes[channel_mode];
         uint8_t err = tint_func(event, arg);
         if (EVENT_HANDLED == err) return EVENT_HANDLED;


### PR DESCRIPTION
If a light has a custom 3H function specified for a channel, it would always call the custom function, not just during 3H events. It would only return if the event was handled by the custom function, but would fall out of the if/else otherwise, preventing later events from being handled.

This prevented access to the 9H channel config in HSV mode, for instance.