### PR TITLE
Fix handling of DEFAULT_BIKING_LEVEL and MAX_BIKING_LEVEL.

### DIFF
--- a/ui/anduril/strobe-modes.h
+++ b/ui/anduril/strobe-modes.h
@@ -55,13 +55,15 @@ inline void lightning_storm_iter();
 
 // bike mode config options
 #ifdef USE_BIKE_FLASHER_MODE
+    #if !defined(MAX_BIKING_LEVEL)
+        #define MAX_BIKING_LEVEL 120  // should be 127 or less
+    #endif
     #if !defined(DEFAULT_BIKING_LEVEL)
-        #define DEFAULT_BIKING_LEVEL  (RAMP_SIZE/3)
+        #define DEFAULT_BIKING_LEVEL (RAMP_SIZE/3)
     #elif DEFAULT_BIKING_LEVEL > MAX_BIKING_LEVEL
         #undef DEFAULT_BIKING_LEVEL
-        #define DEFAULT_BIKING_LEVEL  MAX_BIKING_LEVEL
+        #define DEFAULT_BIKING_LEVEL MAX_BIKING_LEVEL
     #endif
-    #define MAX_BIKING_LEVEL 120  // should be 127 or less
     inline void bike_flasher_iter();
 #endif  // ifdef USE_BIKE_FLASHER_MODE
 


### PR DESCRIPTION
Previously MAX_BIKING_LEVEL was set after DEFAULT_BIKING_LEVEL by default, so the default just ended up getting set to the max. Also makes it possible to override the max level. Fixes #111 