### PR TITLE
Manual: Add default for post-off voltage display

### DIFF
--- a/docs/anduril-manual.md
+++ b/docs/anduril-manual.md
@@ -453,7 +453,7 @@ The voltage config menu has these settings:
      This setting determines how many seconds the RGB aux LEDs
      display the voltage color after the torch goes to sleep.  Click
      once per desired second, or zero times to turn this function
-     off.
+     off. The default is 4 seconds.
 
 ### Temperature check:
 


### PR DESCRIPTION
The post-off voltage display is a feature that causes initial confusion for many; cf. the discussion in this recent [poll over at BLF](https://budgetlightforum.com/t/poll-would-you-like-post-off-voltage-display-povd-to-be-disabled-by-default/226209). So it may be helpful to include the present default of 4 seconds in order to dissipate at least some of the confusion.

The documentation of the post-off voltage display is also addressed with https://github.com/ToyKeeper/anduril/pull/51, by adding the post-off voltage display feature as the first question to an FAQ before the UI Reference Table.