### PR TITLE
Manual: Document extra digit for battery check

### DIFF
--- a/docs/anduril-manual.md
+++ b/docs/anduril-manual.md
@@ -417,13 +417,27 @@ In more detail, this is what each blinky / utility mode does:
 
 ### Battery check:
 
-Blinks out the battery voltage per cell.  Full is 4.2V, empty is
-about 3.0V.  The light blinks the whole-number digit first, pauses,
-then blinks out the "tenths" digit.  Then a longer pause, and it
-repeats.
-So for 4.2V, it would be "blink-blink-blink-blink .. blink-blink".
+Blinks out the battery voltage per cell.  Full is 4.20V, empty is
+about 3.00V.  The light blinks the whole-number digit first, pauses,
+then blinks out the "tenths" digit, pauses, then blinks out the
+"hundredths" digit, in 0.02V steps.  Then a longer pause, and it
+repeats.  So for 4.16V, it would be "blink-blink-blink-blink .. blink
+.. blink-blink-blink-blink-blink-blink".
 
 A "zero" digit is represented by a very quick blink.
+
+The battery check format has changed a few times:
+
+ - For Anduril 2 from 2024-04 or later, the battery voltage resolution
+   is 0.02V steps (the last digit can be 0, 2, 4, 6, or 8).
+
+ - For Anduril 2 from 2023-12 or later, the battery voltage resolution
+   is 0.025V steps (the last digit can be 0, 2, 5, or 7).
+
+ - For Anduril 2 from 2023-12 or earlier, the battery voltage resolution
+   is 0.1V, so the light blinks the whole-number digit first, pauses,
+   then blinks out the "tenths" digit.  Then a longer pause, and it
+   repeats.
 
 On lights with more than one set of LEDs, pressing `3C` during batt
 check mode can select which set of LEDs (which channel mode) it uses


### PR DESCRIPTION
For some time, there has been a two decimal voltage resolution for battery check via 3C from Off. Previously, there used to be a one decimal voltage resolution. So far, this extra digit has not been documented in the manual; the different battery check formats could be documented in a way similar to the different [Version Check Formats](https://github.com/ToyKeeper/anduril/blob/trunk/docs/anduril-manual.md#version-check-formats).

Related: For a request to make voltage readout decimal place user configurable, cf. https://github.com/ToyKeeper/anduril/issues/74.