### PR TITLE
Manual: Add how to check which UI the user is in

### DIFF
--- a/docs/anduril-manual.md
+++ b/docs/anduril-manual.md
@@ -187,6 +187,11 @@ Advanced UI
 Most of the information below this is for the Advanced UI.  Anything not
 already noted above is blocked in the Simple UI.
 
+To check which UI the user is in, Simple UI or Advanced UI, the user can do
+a battery check with `3C` from Off:  In Simple UI, the battery voltage will
+be displayed once, whereas in Advanced UI, the battery voltage will be
+displayed continuously.
+
 
 Ramping / Stepped Ramping Modes
 -------------------------------


### PR DESCRIPTION
It could be helpful to clarify how to determine which UI the user is in, Simple UI or Advanced UI. This determination can be tricky at times, especially with Extended Simple UI, which makes otherwise Advanced UI features accessible in Simple UI. Futhermore, iirc for example Hank ships with Advanced UI enabled, while the manual states that a simple UI is the [default](https://github.com/ToyKeeper/anduril/blob/e43203f814c7040c49dbb7d4804e9f2008633b7b/docs/anduril-manual.md?plain=1#L91C1-L91C40), and that Simple UI is enabled after each [factory reset](https://github.com/ToyKeeper/anduril/blob/e43203f814c7040c49dbb7d4804e9f2008633b7b/docs/anduril-manual.md?plain=1#L85C1-L85C47).

A straightforward method to tell the two UIs apart is to do a battery check. Currently, the manual mentions that in Simple UI, voltage is displayed [once](https://github.com/ToyKeeper/anduril/blob/e43203f814c7040c49dbb7d4804e9f2008633b7b/docs/anduril-manual.md?plain=1#L113C33-L113C70), and in the battery check section of the Advanced UI part, that it [repeats](https://github.com/ToyKeeper/anduril/blob/e43203f814c7040c49dbb7d4804e9f2008633b7b/docs/anduril-manual.md?plain=1#L422C38-L423C9).

These two pieces of information are currently somewhat spread over the manual, and may not be easy to find. So it could help to document the battery check method to check which UI the user is in. This could be done in the Advanced UI section right after the Simple UI part, as proposed in this pull request.

fwiw, emphasizing the UI voltage display for Simple UI and for Advanced UI at batt check is the latest change to this [diagram](https://github.com/dirtydancing/anduril-tikz-diagram) by myself, cf. its [changelog](https://github.com/dirtydancing/anduril-tikz-diagram/blob/main/CHANGELOG.md#2024-04-2034-date-2025-01-21).