### PR TITLE
Manual: Document 3H for auto-tint

### DIFF
--- a/docs/anduril-manual.md
+++ b/docs/anduril-manual.md
@@ -1020,6 +1020,7 @@ This is a table of all button mappings in Anduril, in one place:
 | :---           | :--    | ------: | :-----
 | Any            | Any    | `3C`    | Next channel mode (i.e. next color mode)
 | Any            | Any    | `3H`    | Tint ramp (if this mode can)
+|                |        |         | Auto-tint: reverse ramp
 | Any            | Full   | `9H`    | Channel mode enable/disable menu:
 |                |        |         | N: click (or not) to enable (disable) mode N
 


### PR DESCRIPTION
It may be useful to document that in the auto-tint channel mode, 3H reverses the ramp. This could be done by adding auto-tint to the UI Reference Table at the end of the manual, as proposed here.

Currently, the manual text mentions [auto-tint](https://github.com/ToyKeeper/anduril/blob/e43203f814c7040c49dbb7d4804e9f2008633b7b/docs/anduril-manual.md?plain=1#L913), but does not specify the 3H action for it; it only documents ["Adjust current channel mode"](https://github.com/ToyKeeper/anduril/blob/e43203f814c7040c49dbb7d4804e9f2008633b7b/docs/anduril-manual.md?plain=1#L904C11-L904C27) in general, and in the UI Reference Table, 3H for multi-channel lights is currently limited to [tint ramp](https://github.com/ToyKeeper/anduril/blob/e43203f814c7040c49dbb7d4804e9f2008633b7b/docs/anduril-manual.md?plain=1#L1022).