### PR TITLE
New feature: Allows use of two different auxiliary LED colors between simple and advanced modes

### DIFF
--- a/ui/anduril/aux-leds.h
+++ b/ui/anduril/aux-leds.h
@@ -39,6 +39,11 @@ const PROGMEM uint8_t rgb_led_colors[] = {
 #define RGB_LED_OFF_DEFAULT 0x19  // low, voltage
 //#define RGB_LED_OFF_DEFAULT 0x18  // low, rainbow
 #endif
+#ifdef INDEPENDENT_AUX_RGB_LEDS
+    #ifndef RGB_LED_SIMPLE_OFF_DEFAULT
+        #define RGB_LED_SIMPLE_OFF_DEFAULT 0x12
+    #endif
+#endif
 #ifndef RGB_LED_LOCKOUT_DEFAULT
 #define RGB_LED_LOCKOUT_DEFAULT 0x39  // blinking, voltage
 //#define RGB_LED_LOCKOUT_DEFAULT 0x37  // blinking, disco

--- a/ui/anduril/config-default.h
+++ b/ui/anduril/config-default.h
@@ -44,6 +44,8 @@
 // Include a simplified UI for non-enthusiasts?
 #define USE_SIMPLE_UI
 
+// Allows use of two different auxiliary LED colors between simple and advanced modes
+#define INDEPENDENT_AUX_RGB_LEDS
 
 ///// Ramp mode options /////
 

--- a/ui/anduril/config-default.h
+++ b/ui/anduril/config-default.h
@@ -45,7 +45,7 @@
 #define USE_SIMPLE_UI
 
 // Allows use of two different auxiliary LED colors between simple and advanced modes
-#define INDEPENDENT_AUX_RGB_LEDS
+// #define INDEPENDENT_AUX_RGB_LEDS
 
 ///// Ramp mode options /////
 

--- a/ui/anduril/load-save-config-fsm.h
+++ b/ui/anduril/load-save-config-fsm.h
@@ -105,6 +105,9 @@ typedef struct Config {
     #ifdef USE_AUX_RGB_LEDS
         uint8_t rgb_led_off_mode;
         uint8_t rgb_led_lockout_mode;
+        #ifdef INDEPENDENT_AUX_RGB_LEDS
+        uint8_t rgb_led_simple_off_mode;
+        #endif
         #ifdef USE_POST_OFF_VOLTAGE
             uint8_t post_off_voltage;
         #endif

--- a/ui/anduril/load-save-config.h
+++ b/ui/anduril/load-save-config.h
@@ -148,6 +148,9 @@ Config cfg = {
     #ifdef USE_AUX_RGB_LEDS
         .rgb_led_off_mode = RGB_LED_OFF_DEFAULT,
         .rgb_led_lockout_mode = RGB_LED_LOCKOUT_DEFAULT,
+        #ifdef INDEPENDENT_AUX_RGB_LEDS
+            .rgb_led_simple_off_mode = RGB_LED_SIMPLE_OFF_DEFAULT,
+        #endif
         #ifdef USE_POST_OFF_VOLTAGE
             // display voltage readout for a while after turning off?
             .post_off_voltage = DEFAULT_POST_OFF_VOLTAGE_SECONDS,

--- a/ui/anduril/off-mode.c
+++ b/ui/anduril/off-mode.c
@@ -78,7 +78,16 @@ uint8_t off_state(Event event, uint16_t arg) {
         #ifdef USE_INDICATOR_LED
         indicator_led_update(cfg.indicator_led_mode & 0x03, arg);
         #elif defined(USE_AUX_RGB_LEDS)
+        #ifdef INDEPENDENT_AUX_RGB_LEDS
+        if (cfg.simple_ui_active == 1) {
+            rgb_led_update(cfg.rgb_led_simple_off_mode, arg);
+        }
+        else {
+            rgb_led_update(cfg.rgb_led_off_mode, arg);
+        }
+        #else
         rgb_led_update(cfg.rgb_led_off_mode, arg);
+        #endif
         #endif
 
         #ifdef USE_AUTOLOCK
@@ -285,10 +294,25 @@ uint8_t off_state(Event event, uint16_t arg) {
     #elif defined(USE_AUX_RGB_LEDS)
     // 7 clicks: change RGB aux LED pattern
     else if (event == EV_7clicks) {
+        #ifdef INDEPENDENT_AUX_RGB_LEDS
+        if (cfg.simple_ui_active == 1) {
+            uint8_t mode = (cfg.rgb_led_simple_off_mode >> 4) + 1;
+            mode = mode % RGB_LED_NUM_PATTERNS;
+            cfg.rgb_led_simple_off_mode = (mode << 4) | (cfg.rgb_led_simple_off_mode & 0x0f);
+            rgb_led_update(cfg.rgb_led_simple_off_mode, 0);
+        }
+        else {
+            uint8_t mode = (cfg.rgb_led_off_mode >> 4) + 1;
+            mode = mode % RGB_LED_NUM_PATTERNS;
+            cfg.rgb_led_off_mode = (mode << 4) | (cfg.rgb_led_off_mode & 0x0f);
+            rgb_led_update(cfg.rgb_led_off_mode, 0);
+        }
+        #else
         uint8_t mode = (cfg.rgb_led_off_mode >> 4) + 1;
         mode = mode % RGB_LED_NUM_PATTERNS;
         cfg.rgb_led_off_mode = (mode << 4) | (cfg.rgb_led_off_mode & 0x0f);
         rgb_led_update(cfg.rgb_led_off_mode, 0);
+        #endif
         save_config();
         blink_once();
         return EVENT_HANDLED;
@@ -296,6 +320,26 @@ uint8_t off_state(Event event, uint16_t arg) {
     // 7 clicks (hold last): change RGB aux LED color
     else if (event == EV_click7_hold) {
         setting_rgb_mode_now = 1;
+        #ifdef INDEPENDENT_AUX_RGB_LEDS
+        if (0 == (arg & 0x3f)) {
+            if (cfg.simple_ui_active == 1) {
+                uint8_t mode = (cfg.rgb_led_simple_off_mode & 0x0f) + 1;
+                mode = mode % RGB_LED_NUM_COLORS;
+                cfg.rgb_led_simple_off_mode = mode | (cfg.rgb_led_simple_off_mode & 0xf0);
+            }
+            else {
+                uint8_t mode = (cfg.rgb_led_off_mode & 0x0f) + 1;
+                mode = mode % RGB_LED_NUM_COLORS;
+                cfg.rgb_led_off_mode = mode | (cfg.rgb_led_off_mode & 0xf0);
+            }
+        }
+        if (cfg.simple_ui_active == 1) {
+            rgb_led_update(cfg.rgb_led_simple_off_mode, arg);
+        }
+        else {
+            rgb_led_update(cfg.rgb_led_off_mode, arg);
+        }
+        #else
         if (0 == (arg & 0x3f)) {
             uint8_t mode = (cfg.rgb_led_off_mode & 0x0f) + 1;
             mode = mode % RGB_LED_NUM_COLORS;
@@ -303,6 +347,7 @@ uint8_t off_state(Event event, uint16_t arg) {
             //save_config();
         }
         rgb_led_update(cfg.rgb_led_off_mode, arg);
+        #endif
         return EVENT_HANDLED;
     }
     else if (event == EV_click7_hold_release) {


### PR DESCRIPTION
I'm proposing a new option for users, I think it's a good idea to be able to change the auxiliary colors in simple mode independently of advanced mode and vice versa. This makes it possible to use two different auxiliary LED colors between simple and advanced mode. It could be useful to know which mode you're in, as there's no way to tell them apart at a glance.

What I've done works, but I have no idea if it's the best option for implementing this modification.

I don't know how to do it, but if you think it's a good idea, what would be great would be to be able to activate or deactivate this option directly with settings shortcuts like in misc config, for example.