### PR TITLE
Manual: Clarify turbo style momentary turbo

### DIFF
--- a/docs/anduril-manual.md
+++ b/docs/anduril-manual.md
@@ -283,8 +283,10 @@ While the light is on, a few actions are available:
               0: No turbo, only ceiling.  
               1: Anduril 1 style.  `Ramp -> 2C` goes to full power.  
               2: Anduril 2 style.  `Ramp -> 2C` goes to ceiling,
-                 or goes to full power if user ramped up to ceiling first.
-              This value also affects momentary turbo in Ramp and Off modes.
+                 or goes to full power if user ramped up to ceiling first.  
+              This value also affects momentary turbo in Ramp and Off
+              modes:  If `0: No turbo, only ceiling.` is selected, there
+              will also be no momentary turbo, only momentary ceiling.
     - Item 5: Configure "smooth steps".  
               0: Disable smooth steps.  
               1: Enable smooth steps.


### PR DESCRIPTION
Regarding the turbo style configuration, at present, the manual is somewhat unclear when stating "This value also affects momentary turbo in Ramp and Off modes."

This comes in the same line right after Anduril 2 style and could be understood to refer to this specific Anduril 2 turbo style setting only. If I am not mistaken, of the three turbo style options, Anduril 1 style and Anduril 2 style will go momentary turbo, whereas "No turbo, only ceiling" will go to momentary ceiling (this topic came up together with the turbo styles recently over at BLF, see [this BLF post](https://budgetlightforum.com/t/emisar-ceiling-level-adjustment/231278/33) of mine).

So first, this is to clarify that the "This value ..." sentence refers to the turbo styles in general, not only to Anduril 2 turbo style; this is done by adding two spaces at the end of the previous line, so this sentence starts in a new line.

And second, this is to specify what this sentence means, i.e. what deviates from momentary turbo; this is done by adding "If `0: No turbo, only ceiling.` is selected, there will also be no momentary turbo, only momentary ceiling."