### PR TITLE
Add option to save channel in manual memory mode

### DIFF
--- a/ui/anduril/config-default.h
+++ b/ui/anduril/config-default.h
@@ -223,3 +223,5 @@
 // (but allow disabling this feature per build)
 #define USE_CHANNEL_PER_STROBE
 
+// by default, allow manual memory to save channel info too
+#define MANUAL_MEMORY_SAVE_CHANNEL

--- a/ui/anduril/ramp-mode.c
+++ b/ui/anduril/ramp-mode.c
@@ -715,23 +715,27 @@ void set_level_and_therm_target(uint8_t level) {
 #ifdef USE_MANUAL_MEMORY
 void manual_memory_restore() {
     memorized_level = cfg.manual_memory;
-    #if NUM_CHANNEL_MODES > 1
-        channel_mode = cfg.channel_mode = cfg.manual_memory_channel_mode;
-    #endif
-    #ifdef USE_CHANNEL_MODE_ARGS
-        for (uint8_t i=0; i<NUM_CHANNEL_MODES; i++)
-          cfg.channel_mode_args[i] = cfg.manual_memory_channel_args[i];
+    #ifdef MANUAL_MEMORY_SAVE_CHANNEL
+        #if NUM_CHANNEL_MODES > 1
+            channel_mode = cfg.channel_mode = cfg.manual_memory_channel_mode;
+        #endif
+        #ifdef USE_CHANNEL_MODE_ARGS
+            for (uint8_t i=0; i<NUM_CHANNEL_MODES; i++)
+              cfg.channel_mode_args[i] = cfg.manual_memory_channel_args[i];
+        #endif
     #endif
 }
 
 void manual_memory_save() {
     cfg.manual_memory = actual_level;
-    #if NUM_CHANNEL_MODES > 1
-        cfg.manual_memory_channel_mode = channel_mode;
-    #endif
-    #ifdef USE_CHANNEL_MODE_ARGS
-        for (uint8_t i=0; i<NUM_CHANNEL_MODES; i++)
-          cfg.manual_memory_channel_args[i] = cfg.channel_mode_args[i];
+    #ifdef MANUAL_MEMORY_SAVE_CHANNEL
+        #if NUM_CHANNEL_MODES > 1
+            cfg.manual_memory_channel_mode = channel_mode;
+        #endif
+        #ifdef USE_CHANNEL_MODE_ARGS
+            for (uint8_t i=0; i<NUM_CHANNEL_MODES; i++)
+              cfg.manual_memory_channel_args[i] = cfg.channel_mode_args[i];
+        #endif
     #endif
 }
 #endif  // ifdef USE_MANUAL_MEMORY


### PR DESCRIPTION
Added the `MANUAL_MEMORY_SAVE_CHANNEL` macro to enable saving and restoring channel mode when using manual memory in multi-channel light.