### PR TITLE
Manual: Add link to POVD section

### DIFF
--- a/docs/anduril-manual.md
+++ b/docs/anduril-manual.md
@@ -1043,8 +1043,9 @@ FAQ
 
 * Q: Why do the aux LEDs come on whenever I switch the light off, regardless
   of aux settings?
-* A: This is the post-off voltage display feature. It can be configured or
-  disabled under [battery check](#battery-check) mode.
+* A: This is the [post-off voltage display](#post-off-voltage-display-povd)
+  feature. It can be configured or disabled under
+  [battery check](#battery-check) mode.
 
 * Q: What can I do to contribute to Anduril development?
 * A: See [Contributing](https://github.com/ToyKeeper/anduril#contributing).


### PR DESCRIPTION
Now that there is a new section on Post-Off Voltage Display (POVD), a link to this section from the FAQ could be added within the manual, like proposed here. This would complement the already existing link in this answer of the FAQ to the Battery check section.

In addition, there could also be links to the POVD section from the Battery check section, voltage config menu, 2., 3., 4., and from the POVD section back to Battery check section again, but all of this seemed a bit much to me, so I left it at a link to the POVD section from the FAQ.