### PR TITLE
Use highest ramp floor for lockout 1H

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,11 @@ formats:
 
 # Next
 
+- Changed lockout momentary moon: `1H` now uses the highest configured ramp
+  floor, matching `2H` when manual memory is not set.  This lets the unused
+  ramp style provide a practical lockout moon level while the primary ramp can
+  still have an ultra-low floor.
+
 # 2025-07-07
 
 Merged a few pull requests, minor improvements, nothing big.  Users can now
@@ -379,4 +384,3 @@ Hardware-specific changes:
 
 
 <!-- vim: set textwidth=78 shiftwidth=2 -->
-

--- a/docs/anduril-manual.md
+++ b/docs/anduril-manual.md
@@ -387,7 +387,7 @@ Lockout mode also doubles as a momentary moon mode, so the user can do
 quick tasks without having to unlock the light.  The brightness in
 lockout mode has two levels:
 
-  - `1H`: Light up at the lowest floor level.
+  - `1H`: Light up at the highest floor level.
 
   - `2H`: Light up at the highest floor level.
           (or the manual mem level, if there is one)
@@ -1125,7 +1125,7 @@ This is a table of all button mappings in Anduril, in one place:
 
 | Mode           | UI     | Button  | Action
 | :---           | :--    | ------: | :-----
-| Lockout        | Any    |`1C`/`1H`| Momentary moon (lowest floor)
+| Lockout        | Any    |`1C`/`1H`| Momentary moon (highest floor)
 | Lockout        | Any    |`2C`/`2H`| Momentary moon (highest floor, or manual mem level)
 | Lockout        | Any    | `3C`    | Unlock (go to "Off" mode)
 | Lockout        | Any    | `3H`    | Next channel mode (if more than one enabled)
@@ -1224,4 +1224,3 @@ This is a table of all button mappings in Anduril, in one place:
 |                |        |         | (goes to Number Entry menu)
 | Number entry   | Full   | Click   | Add 1 to value for current item
 | Number entry   | Full   | Hold    | Add 10 to value for current item
-

--- a/make
+++ b/make
@@ -27,6 +27,7 @@ Usage: ./make TASK
   docs            Convert all .md files to .html
   models          Generate the MODELS file
   release         Zip up all .hex files to prep for publishing a release
+  test            Run host-side regression tests
   version         Show the current version string
   todo            Show tasks noted in source code files
 
@@ -76,6 +77,9 @@ function main() {
     release)
       ./bin/make-release.sh "$@"
       ;;
+    test)
+      ./tests/run-host-tests.sh
+      ;;
     version)
       ./bin/version-string.sh "$@"
       ;;
@@ -122,4 +126,3 @@ cd "$BASEDIR" || (echo "Error: Can't cd to basedir." && exit 1)
 
 # do whatever the user requested
 main "$@"
-

--- a/tests/lockout-momentary-level.c
+++ b/tests/lockout-momentary-level.c
@@ -1,0 +1,53 @@
+// Regression tests for Anduril lockout momentary level selection.
+// Copyright (C) 2026 Selene ToyKeeper
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "anduril/lockout-mode-levels.h"
+
+static int check_level(
+        const char *name,
+        uint8_t click_num,
+        uint8_t floor_a,
+        uint8_t floor_b,
+        uint8_t manual_memory,
+        uint8_t expected) {
+    uint8_t actual = lockout_momentary_level(
+            click_num,
+            floor_a,
+            floor_b,
+            manual_memory);
+
+    if (actual == expected) return 0;
+
+    fprintf(stderr,
+            "%s: expected %u, got %u "
+            "(click=%u floor_a=%u floor_b=%u manual_memory=%u)\n",
+            name,
+            expected,
+            actual,
+            click_num,
+            floor_a,
+            floor_b,
+            manual_memory);
+    return 1;
+}
+
+int main(void) {
+    int failures = 0;
+
+    failures += check_level("1H uses stepped floor when stepped is higher",
+            1, 1, 20, 0, 20);
+    failures += check_level("1H uses smooth floor when smooth is higher",
+            1, 25, 3, 0, 25);
+    failures += check_level("2H uses highest floor without manual memory",
+            2, 1, 20, 0, 20);
+    failures += check_level("2H uses manual memory when configured",
+            2, 1, 20, 42, 42);
+    failures += check_level("1H ignores manual memory",
+            1, 1, 20, 42, 20);
+
+    return failures ? 1 : 0;
+}

--- a/tests/run-host-tests.sh
+++ b/tests/run-host-tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Run host-side regression tests which do not need avr-gcc.
+# Copyright (C) 2026 Selene ToyKeeper
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -euo pipefail
+
+cc -Wall -Wextra -std=c99 -I ui -o /tmp/anduril-lockout-momentary-level-test \
+  tests/lockout-momentary-level.c
+
+/tmp/anduril-lockout-momentary-level-test

--- a/ui/anduril/lockout-mode-levels.h
+++ b/ui/anduril/lockout-mode-levels.h
@@ -1,0 +1,21 @@
+// lockout-mode-levels.h: Level selection helpers for Anduril lockout mode.
+// Copyright (C) 2017-2026 Selene ToyKeeper
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <stdint.h>
+
+static inline uint8_t lockout_highest_floor(uint8_t floor_a, uint8_t floor_b) {
+    if (floor_b > floor_a) return floor_b;
+    return floor_a;
+}
+
+static inline uint8_t lockout_momentary_level(
+        uint8_t click_num,
+        uint8_t floor_a,
+        uint8_t floor_b,
+        uint8_t manual_memory) {
+    if ((2 == click_num) && manual_memory) return manual_memory;
+    return lockout_highest_floor(floor_a, floor_b);
+}

--- a/ui/anduril/lockout-mode.c
+++ b/ui/anduril/lockout-mode.c
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "anduril/lockout-mode.h"
+#include "anduril/lockout-mode-levels.h"
 
 uint8_t lockout_state(Event event, uint16_t arg) {
     #ifdef USE_MOON_DURING_LOCKOUT_MODE
@@ -19,19 +20,16 @@ uint8_t lockout_state(Event event, uint16_t arg) {
         ((B_CLICK | B_PRESS) == (event & (B_CLICK | B_PRESS)))
         && (click_num <= 2)
     ) {
-        uint8_t lvl = cfg.ramp_floors[0];
-        // hold: lowest floor
-        if (1 == click_num) {  // 1st click
-            if (cfg.ramp_floors[1] < lvl) lvl = cfg.ramp_floors[1];
-        }
-        // click, hold: highest floor (or manual mem level)
-        else {  // 2nd click
-            #ifdef USE_MANUAL_MEMORY
-            if (cfg.manual_memory) lvl = cfg.manual_memory;
-            else
-            #endif
-            if (cfg.ramp_floors[1] > lvl) lvl = cfg.ramp_floors[1];
-        }
+        uint8_t manual_memory = 0;
+        #ifdef USE_MANUAL_MEMORY
+        manual_memory = cfg.manual_memory;
+        #endif
+
+        uint8_t lvl = lockout_momentary_level(
+                click_num,
+                cfg.ramp_floors[0],
+                cfg.ramp_floors[1],
+                manual_memory);
         off_state_set_level(lvl);
     }
     // button was released
@@ -222,4 +220,3 @@ uint8_t autolock_config_state(Event event, uint16_t arg) {
     return config_state_base(event, arg, 1, autolock_config_save);
 }
 #endif  // #ifdef USE_AUTOLOCK
-


### PR DESCRIPTION
## Summary
This changes Lockout Mode momentary moon behavior so 1H uses the highest configured ramp floor instead of the lowest. 2H keeps its existing behavior: it uses manual memory when configured, otherwise the highest configured ramp floor.

This lets users keep an ultra-low floor on their primary ramp, while using the other ramp style’s floor as a practical lockout moon level.

## Behavior change

Before:

  - 1H: lowest of smooth/stepped ramp floors
  - 2H: highest of smooth/stepped ramp floors, or manual memory if set

After:

  - 1H: highest of smooth/stepped ramp floors
  - 2H: highest of smooth/stepped ramp floors, or manual memory if set

## Implementation notes

The change is intentionally small: the lockout path now calls a tiny level-selection helper, with no new config state and no changes to ramp setup, manual memory, or lockout exit behavior. The helper is static inline, so it should compile away while making the rule easy to test directly.

## Docs and tests

  - Updated the manual and changelog to describe the new 1H behavior.
  - Added ./make test with a host-side regression test covering:
      - 1H uses the higher floor
      - either ramp floor can be higher
      - 2H still uses the higher floor without manual memory
      - 2H still honors manual memory
      - 1H does not use manual memory

## Testing

  - Passed: `make test`
  - Not run locally: AVR firmware build