### PR TITLE
Manual: Specify voltage for RGB aux while on

### DIFF
--- a/docs/anduril-manual.md
+++ b/docs/anduril-manual.md
@@ -503,7 +503,8 @@ The voltage config menu has these settings:
 
   5. Aux while on.  Determines which aux LEDs will be lit up while the main
      LEDs are on, like in ramping mode:  
-     0 = none, 1 = single color aux only, 2 = RGB aux only, 3 = both.
+     0 = none, 1 = single color aux only, 2 = RGB aux only, 3 = both.  
+     RGB aux LEDs while on always display the voltage color.
 
 ### Temperature check:
 


### PR DESCRIPTION
Regarding the documentation of the new option 5 in Voltage Config, aux while on, see https://github.com/ToyKeeper/anduril/commit/0b67f60aa01410bca12fec02ee8f228d17c79606, it may be useful to specify that RGB aux LEDs while on always display the voltage color (unless this has changed).