### PR TITLE
Manual: Add aux while on to inherited options

### DIFF
--- a/docs/anduril-manual.md
+++ b/docs/anduril-manual.md
@@ -182,6 +182,7 @@ and they will carry over to Simple UI:
   - voltage calibration
   - post-off voltage display
   - aux led low and high ramp levels
+  - aux LEDs while on
   - thermal regulation settings
   - hardware-specific "misc menu" settings
   - channel modes


### PR DESCRIPTION
Now that the manual documents aux while on as new option 5 in Voltage Config, see https://github.com/ToyKeeper/anduril/commit/0b67f60aa01410bca12fec02ee8f228d17c79606, this new option should also be added to the options inherited by Simple UI (I checked, and it is inherited).