### PR TITLE
Manual: Capitalize LED for consistency

### DIFF
--- a/docs/anduril-manual.md
+++ b/docs/anduril-manual.md
@@ -181,7 +181,7 @@ and they will carry over to Simple UI:
   - aux LED settings
   - voltage calibration
   - post-off voltage display
-  - aux led low and high ramp levels
+  - aux LED low and high ramp levels
   - thermal regulation settings
   - hardware-specific "misc menu" settings
   - channel modes


### PR DESCRIPTION
In the inherited options above the proposed addition of `aux LEDs while on`, see https://github.com/ToyKeeper/anduril/pull/172, this replaces `led` with `LED` for consistency (now `aux LED low and high ramp levels`), as `LED`/`LEDs` is capitalized throughout the manual.