### PR TITLE
Add optional RGB aux voltage channel mode

### DIFF
--- a/fsm/chan-rgbaux.c
+++ b/fsm/chan-rgbaux.c
@@ -36,9 +36,31 @@ void set_level_auxwht(uint8_t level) {
 // returns a ready-made set_auxrgb_power() pattern chosen by battery voltage
 uint8_t voltage_to_rgb();
 
+#ifdef USE_DIMMABLE_AUXRGB
+// defined later in this translation unit, in <hwdef>.c, which includes this
+// file before its own forward declarations for these two are in scope
+rgb_uint_t get_level_auxrgb(uint8_t level);
+void set_auxrgb_pwm(RGB_t color);
+#endif
+
 void set_level_auxvoltage(uint8_t level) {
-    // same shape as the fixed-color modes above, only the color varies
-    set_auxrgb_power(voltage_to_rgb() << !(!(level)));  // high (level > 0) or low
+    #ifdef USE_DIMMABLE_AUXRGB
+        // this channel is a readout, not a brightness control, so an aux
+        // channel blinks at full power instead of at the requested level
+        rgb_uint_t bright = 0;
+        if (level) bright = get_level_auxrgb(
+            channel_is_aux(channel_mode) ? RAMP_SIZE : level);
+        uint8_t pattern = voltage_to_rgb();
+        RGB_t color = {
+            .r = ((pattern >> 0) & 1) ? bright : 0,
+            .g = ((pattern >> 2) & 1) ? bright : 0,
+            .b = ((pattern >> 4) & 1) ? bright : 0,
+        };
+        set_auxrgb_pwm(color);
+    #else
+        // same shape as the fixed-color modes above, only the color varies
+        set_auxrgb_power(voltage_to_rgb() << !(!(level)));  // high (level > 0) or low
+    #endif
 }
 #endif
 

--- a/fsm/chan-rgbaux.c
+++ b/fsm/chan-rgbaux.c
@@ -31,5 +31,16 @@ void set_level_auxwht(uint8_t level) {
     set_auxrgb_power(0b010101 << !(!(level)));  // red+green+blue, high (level > 0) or low
 }
 
+#ifdef USE_AUX_VOLTAGE_CHANNEL_MODE
+// defined in anduril/aux-leds.c, which the UI includes after this file;
+// returns a ready-made set_auxrgb_power() pattern chosen by battery voltage
+uint8_t voltage_to_rgb();
+
+void set_level_auxvoltage(uint8_t level) {
+    // same shape as the fixed-color modes above, only the color varies
+    set_auxrgb_power(voltage_to_rgb() << !(!(level)));  // high (level > 0) or low
+}
+#endif
+
 bool gradual_tick_null(uint8_t gt) { return true; }  // do nothing
 

--- a/fsm/chan-rgbaux.h
+++ b/fsm/chan-rgbaux.h
@@ -5,6 +5,20 @@
 
 #define USE_CHANNEL_FLAGS
 
+// Optional RGB aux voltage channel mode: color follows battery voltage.
+// It can be selected as DEFAULT_BLINK_CHANNEL to produce voltage-colored
+// number blinks.  Opt-in, because NUM_AUXRGB_CHANNEL_MODES sizes
+// cfg.channel_mode_args on every light that has RGB aux LEDs.
+#ifdef USE_AUX_VOLTAGE_CHANNEL_MODE
+    #define AUXRGB_VOLTAGE_ENUM        , CM_AUXVOLTAGE
+    #define AUXRGB_VOLTAGE_CM_ARG      ,0
+    #define NUM_AUXRGB_CHANNEL_MODES   8
+#else
+    #define AUXRGB_VOLTAGE_ENUM
+    #define AUXRGB_VOLTAGE_CM_ARG
+    #define NUM_AUXRGB_CHANNEL_MODES   7
+#endif
+
 #define AUXRGB_CM_ENUMS  \
     CM_AUXRED, \
     CM_AUXYEL, \
@@ -12,11 +26,10 @@
     CM_AUXCYN, \
     CM_AUXBLU, \
     CM_AUXPRP, \
-    CM_AUXWHT
+    CM_AUXWHT \
+    AUXRGB_VOLTAGE_ENUM
 
-#define AUXRGB_CM_ARGS  0,0,0,0,0,0,0
-
-#define NUM_AUXRGB_CHANNEL_MODES  7
+#define AUXRGB_CM_ARGS  0,0,0,0,0,0,0 AUXRGB_VOLTAGE_CM_ARG
 
 // include / exclude field based on compile options
 #ifdef USE_CHANNEL_FLAGS
@@ -60,7 +73,20 @@
         .set_level    = set_level_auxwht, \
         .gradual_tick = gradual_tick_null \
         AUXRGB_FLAGS \
+    } \
+    AUXRGB_VOLTAGE_CHANNEL
+
+#ifdef USE_AUX_VOLTAGE_CHANNEL_MODE
+#define AUXRGB_VOLTAGE_CHANNEL \
+    , { \
+        .set_level    = set_level_auxvoltage, \
+        .gradual_tick = gradual_tick_null \
+        AUXRGB_FLAGS \
     }
+void set_level_auxvoltage(uint8_t level);
+#else
+#define AUXRGB_VOLTAGE_CHANNEL
+#endif
 
 void set_level_auxred(uint8_t level);
 void set_level_auxyel(uint8_t level);

--- a/fsm/chan-rgbaux.h
+++ b/fsm/chan-rgbaux.h
@@ -80,8 +80,8 @@
 #define AUXRGB_VOLTAGE_CHANNEL \
     , { \
         .set_level    = set_level_auxvoltage, \
-        .gradual_tick = gradual_tick_null \
-        AUXRGB_FLAGS \
+        .gradual_tick = gradual_tick_null, \
+        .flags        = CHANNEL_FLAG_IS_AUX | CHANNEL_FLAG_BLINK_ONLY \
     }
 void set_level_auxvoltage(uint8_t level);
 #else

--- a/fsm/channels.h
+++ b/fsm/channels.h
@@ -75,6 +75,15 @@ StatePtr channel_3H_modes[NUM_CHANNEL_MODES];
 // which modes are displayed on the aux LEDs?
 #define channel_is_aux(n)    (channels[n].flags & CHANNEL_FLAG_IS_AUX)
 
+#ifdef USE_AUX_VOLTAGE_CHANNEL_MODE
+// modes whose output is derived from live data, and which therefore only
+// make sense for number blinks (where set_level() runs for every blink)
+#define CHANNEL_FLAG_BLINK_ONLY  0b00000100
+#define channel_blink_only(n)    (channels[n].flags & CHANNEL_FLAG_BLINK_ONLY)
+#else
+#define channel_blink_only(n)    0
+#endif
+
 #ifdef USE_CHANNEL_MODE_ARGS
     #ifndef USE_CFG
     // one byte of extra data per channel mode, like for tint value

--- a/hw/hank/emisar-d3aa/hwdef.h
+++ b/hw/hank/emisar-d3aa/hwdef.h
@@ -139,6 +139,8 @@ enum channel_modes_e {
 
 // this light has RGB aux LEDs
 #define USE_AUXRGB_LEDS
+// ... and the aux RGB is dimmable, not just on/off
+#define USE_DIMMABLE_AUXRGB
 
 // aux RGB passive
 #define AUXRGB_R_PORT  PORTA

--- a/hw/hank/lume-x1/hwdef.h
+++ b/hw/hank/lume-x1/hwdef.h
@@ -122,6 +122,8 @@ enum channel_modes_e {
 // this light has RGB aux LEDs
 // (and some builds tie these also to a RGB side button)
 #define USE_AUXRGB_LEDS
+// ... and the aux RGB is dimmable, not just on/off
+#define USE_DIMMABLE_AUXRGB
 
 // aux RGB passive
 #define AUXRGB_R_PORT  PORTA

--- a/hw/thefreeman/avr32dd20-devkit/hwdef.h
+++ b/hw/thefreeman/avr32dd20-devkit/hwdef.h
@@ -133,6 +133,8 @@ uint8_t voltage_raw2cooked(uint16_t measurement);
 
 // this light has RGB aux LEDs
 #define USE_AUXRGB_LEDS
+// ... and the aux RGB is dimmable, not just on/off
+#define USE_DIMMABLE_AUXRGB
 
 // aux RGB passive
 #define AUXRGB_R_PORT  PORTA

--- a/hw/thefreeman/boost21-mp3431-hdr-dac-argb/hwdef.h
+++ b/hw/thefreeman/boost21-mp3431-hdr-dac-argb/hwdef.h
@@ -107,6 +107,8 @@ enum channel_modes_e {
 
 // this light has RGB aux LEDs
 #define USE_AUXRGB_LEDS
+// ... and the aux RGB is dimmable, not just on/off
+#define USE_DIMMABLE_AUXRGB
 
 // aux RGB passive
 #define AUXRGB_R_PORT  PORTB

--- a/ui/anduril/channel-modes.c
+++ b/ui/anduril/channel-modes.c
@@ -34,7 +34,8 @@ uint8_t channel_mode_state(Event event, uint16_t arg) {
         do {
             count ++;
             next = (next + 1) % NUM_CHANNEL_MODES;
-        } while ((! channel_mode_enabled(next)) && count < NUM_CHANNEL_MODES);
+        } while (((! channel_mode_enabled(next)) || channel_blink_only(next))
+                 && count < NUM_CHANNEL_MODES);
         //} while ((! channel_modes_enabled[next]) && count < NUM_CHANNEL_MODES);
 
         // undo change if infinite loop detected (redundant?)

--- a/ui/anduril/ramp-mode.c
+++ b/ui/anduril/ramp-mode.c
@@ -403,7 +403,7 @@ uint8_t steady_state(Event event, uint16_t arg) {
             if (event == EV_3clicks) {
                 uint8_t enabled = 0;
                 for (uint8_t m=0; m<NUM_CHANNEL_MODES; m++)
-                    enabled += channel_mode_enabled(m);
+                    enabled += channel_mode_enabled(m) && (! channel_blink_only(m));
                 if (enabled > 1)
                     return EVENT_NOT_HANDLED;
             }


### PR DESCRIPTION
## Summary

- add an opt-in `CM_AUXVOLTAGE` channel mode for RGB aux LEDs
- reuse Anduril's existing `voltage_to_rgb()` mapping instead of defining another color scale
- make the mode structurally blink-only, so it cannot be selected as a steady ramp channel even from the channel-mode config menu
- on hardware with dimmable RGB aux, drive the readout through `set_auxrgb_pwm()` at full brightness instead of the on/off `set_auxrgb_power()` path
- allow builds to select it as `DEFAULT_BLINK_CHANNEL`, producing voltage-colored number blinks for battery, temperature, and version readouts

When `CM_AUXVOLTAGE` is selected as the blink channel, 3C from Batt Check still reports battery voltage numerically, while the blink color follows Anduril's existing voltage color scale. For example, at 3.9 V, it blinks out "3.9" in blue. The color of the very first blink therefore gives an approximate charge-level indication before the full numeric readout finishes.

## Design

The feature is gated by `USE_AUX_VOLTAGE_CHANNEL_MODE`. This is necessary because adding a channel changes `NUM_AUXRGB_CHANNEL_MODES`, which sizes the channel-mode argument array and affects the EEPROM layout. With the gate disabled, the existing seven RGB aux channel modes and their generated firmware remain byte-identical to upstream.

**Answer to "a voltage-derived color freezes in steady modes because `set_level()` runs once":** a new `CHANNEL_FLAG_BLINK_ONLY` bit in `fsm/channels.h`, in the same idiom as the existing `CHANNEL_FLAG_HAS_ARGS` / `CHANNEL_FLAG_IS_AUX`, folds to a literal `0` when the gate is off. The 3C channel cycler in `ui/anduril/channel-modes.c` and the enabled-mode count in `ui/anduril/ramp-mode.c` both skip blink-only modes, so `CM_AUXVOLTAGE` cannot be reached from the ramp even after a user re-enables it in the channel-mode config menu. `battcheck_state`'s 3C cycler does not consult flags, so the mode stays reachable exactly where `set_level()` is called for every digit.

**Answer to "newer lights have dimmable RGB the patch does not speak to":** a new `USE_DIMMABLE_AUXRGB` hwdef macro names the four targets whose `hwdef.c` already provides `get_level_auxrgb()` / `set_auxrgb_pwm()`. When it is defined, `set_level_auxvoltage()` builds an `RGB_t` from the same bit-0/2/4 pattern `voltage_to_rgb()` already returns and sends it through `set_auxrgb_pwm()` at full brightness (`get_level_auxrgb(RAMP_SIZE)`), so the readout is visible instead of clipped to on/off. Non-dimmable hardware keeps the unchanged `set_auxrgb_power()` one-liner. The seven discrete POVD colors are used on both paths; there is no interpolation — a digit is a discrete symbol, and a color shift mid-readout is deliberately kept as a sag signal, not smoothed away.

Open question: if the "Batt Color" work already introduced a macro for this same hardware fact, that macro should be used instead of `USE_DIMMABLE_AUXRGB` — happy to rename to match once it exists.

This is separate from the existing Voltage standby aux color. The existing setting controls off/lockout aux behavior; this change exposes the same voltage-to-color mapping through Anduril's channel-mode interface.

## Verification

- gate-off `hank-emisar-d3aa` build is byte-identical to upstream under a forced identical version string: md5 `73479624961b3767ab36e49d54471ddb`, 13448 B / 41.0 %
- gate-on builds compile and fit: Emisar D3AA (`avr32dd20`) 13524 B / 41.3 %, Emisar D2 (`attiny1634`) 12700 B / 77.5 %, Wurkkos TS10 RGB aux (`attiny1616`) 11550 B / 70.5 %
- flashed and exercised on five lights: Emisar D3AA, Noctigon KR1AA, and Emisar DW4 / Lume X1 (all `avr32dd20` with dimmable RGB aux), Emisar D2 (`attiny1634`), and Wurkkos TS10 RGB aux (`attiny1616`). `CM_AUXVOLTAGE` is not reachable from the ramp on any of them, is still reachable as a blink channel from Batt Check, and the readout blinks at full aux brightness on all three dimmable targets. Those were personal builds which carry a few unrelated patches alongside this one; the code under test is identical to this branch's, the surrounding firmware is not stock.

## Configuration example

```c
#define USE_AUX_VOLTAGE_CHANNEL_MODE
#define DEFAULT_BLINK_CHANNEL CM_AUXVOLTAGE
```
